### PR TITLE
Switch to Quarto website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ rsconnect/
 /.quarto/
 .DS_Store
 _book
+_site

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,37 +1,68 @@
 project:
-  type: book
+  type: website
 
-# See also https://quarto.org/docs/reference/projects/books.html
-book:
-  title: "Open Handbook"
+website:
+  site-url: "https://ubvu.github.io/open-handbook"
+  title: "VU Open Handbook"
+  description: "A place for all things open research at the VU."
   favicon: public/VU_social_avatar_blauw.png
-  # cover-image: cover.png
-  navbar: 
-    logo: public/VU_social_avatar_blauw-rectangle.png
-    background: "#0080c9"
-  site-url: https://ubvu.github.io/open-handbook
   repo-url: https://github.com/ubvu/open-handbook
   issue-url: https://github.com/ubvu/open-handbook/issues/new/choose
   repo-actions: [edit, issue]
-  # page-navigation: true
-  # downloads: [pdf, epub]
-  page-footer:
+  page-navigation: true
+  bread-crumbs: true
+  navbar:
+    background: "#0080c9"
+    logo: public/VU_social_avatar_blauw-rectangle.png
+    logo-alt: "VU Amsterdam logo."
+    title: "Open Handbook"
+    # title: false
+    collapse-below: lg
+    favicon: public/VU_social_avatar_blauw.png
     left:
-      - text: "CC0 Public Domain Dedication"
-        href: "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
-    right:
-      - text: "By VU & Liberate Science GmbH"
-  chapters:
-    - index.qmd
-    - part: "Chapters"
-      chapters:
+      - text: "Home"
+        file: index.qmd
+      - text: "Chapters"
+        menu:
+          - chapters/conflict-chapter.qmd
+          - chapters/data-management-plan.qmd
+          - chapters/research-drive.qmd
+          - chapters/fair-data.qmd
+          - chapters/data-publication.qmd
+      - contributing.qmd
+      - references.qmd
+    tools:
+      - icon: github
+        href: https://github.com/ubvu/open-handbook
+        text: GitHub VU Open Handbook
+      # - icon: rss
+      #   href: https://quarto.org/docs/blog/index.xml
+      #   text: Quarto Blog RSS   
+  sidebar:
+    - title: "Tutorials"
+      style: "docked"
+      background: light
+      contents:
         - chapters/conflict-chapter.qmd
         - chapters/data-management-plan.qmd
         - chapters/research-drive.qmd
         - chapters/fair-data.qmd
         - chapters/data-publication.qmd
-    - contributing.qmd
-    - references.qmd
+  page-footer:
+    left:
+      - text: "CC0 Public Domain Dedication"
+        href: "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
+    center:
+      - text: "About"
+        href: about.qmd
+      - text: "FAQ"
+        href: docs/faq/index.qmd
+      - text: "License"
+        href: license.qmd
+      - text: "Trademark"
+        href: trademark.qmd
+    right:
+      - text: "By VU & Liberate Science GmbH"
 
 bibliography: references.bib
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -30,7 +30,6 @@ website:
           - chapters/fair-data.qmd
           - chapters/data-publication.qmd
       - contributing.qmd
-      - references.qmd
     tools:
       - icon: github
         href: https://github.com/ubvu/open-handbook

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -59,12 +59,8 @@ website:
         href: docs/faq/index.qmd
       - text: "License"
         href: license.qmd
-      - text: "Trademark"
-        href: trademark.qmd
     right:
       - text: "By VU & Liberate Science GmbH"
-
-bibliography: references.bib
 
 format:
   html:

--- a/custom.scss
+++ b/custom.scss
@@ -9,9 +9,7 @@ body {
     font-family: 'Roboto';
     line-height: 1.6666666667rem;
 }
-.quarto-navigation-tool {
-    display: none
-}
+
 .quarto-secondary-nav .quarto-search-button  {
     display: none
 }

--- a/index.qmd
+++ b/index.qmd
@@ -1,8 +1,10 @@
-# Welcome {.unnumbered}
+---
+title: Welcome
+---
 
 This is a template for creating (hand)books styled for VU Amsterdam. 
 
-To get started you only need a GitHub account. You can [find the template directly on GitHub]({{< meta book.repo-url >}}). If you need any help to set it up, contact [chris@libscie.org](mailto:chris@libscie.org).
+To get started you only need a GitHub account. You can [find the template directly on GitHub]({{< meta book.repo-url >}}). If you need any help to set it up, contact [chris@libscie.org](mailto:chris@libscie.org).[@knuth84]
 
 ALL WORK AND NO PLAY MAKES JACK A DULL BOY
 ALL WORK AND NO PLAY MAKES JACK A DULL BOY

--- a/references.qmd
+++ b/references.qmd
@@ -1,4 +1,0 @@
-# References {.unnumbered}
-
-::: {#refs}
-:::


### PR DESCRIPTION
This PR changes the Quarto book into a Quarto website, to make for more flexible navigation as requested from one of our meetings. 
