### PR TITLE
Add absolute nav bar

### DIFF
--- a/custom.scss
+++ b/custom.scss
@@ -9,9 +9,11 @@ body {
     font-family: 'Roboto';
     line-height: 1.6666666667rem;
 }
-.quarto-navigation-tool {
-    display: none
+
+.fixed-top {
+    position: absolute;
 }
+
 .quarto-secondary-nav .quarto-search-button  {
     display: none
 }


### PR DESCRIPTION
This PR makes sure the nav bar doesn't show up when opening a page lower than the top. 

Fixes #17.
