### PR TITLE
Remove note to editors from public view

### DIFF
--- a/chapters/data-management-plan.qmd
+++ b/chapters/data-management-plan.qmd
@@ -10,7 +10,6 @@ VU Amsterdam offers the online tool [DMPonline](https://dmponline.vu.nl/) for wr
 
 If you have questions about DMPonline, or encounter problems when using the tool, please get in touch with <rdm@vu.nl>.
 
-
 ## Choosing the right template
 
 Various templates exist in which you can set up your DMP. We strongly recommend that you use the VU template, which is called `VU DMP template 2021 (NWO & ZonMw certified) v1.4`. Below you'll find an explanation of how to access this template. If you need to write a DMP for funding agencies NWO, ZonMw or ERC, you can use the VU template as well.
@@ -51,11 +50,11 @@ However, it is also possible to use other templates in DMPonline. If your funder
 
 Researchers who don't work with personal data and who wish to use another DMP template than the VU template, can also follow the steps above.
 
-## Register your processing activities [(On the GDPR & Privacy page)](https://libguides.vu.nl/rdm/gdpr-privacy?#s-lg-box-wrapper-15125651)
+## Register your processing activities
 
 ### How does registration of personal data processing work in research?
 
-If your research is subject to the (GDPR)[eventually link to a GDPR page], then you need to register information on your research in a central VU registry. This central registry lists all personal data processing activities carried out at the VU. The registry indicates why and how personal data are processed, and with whom they are shared. The registry helps the VU demonstrate compliance with the GDPR and in the case of a data breach, the registry helps with monitoring and acting swiftly to inform all relevant stakeholders. 
+If your research is subject to the [GDPR](https://libguides.vu.nl/rdm/gdpr-privacy), then you need to register information on your research in a central VU registry. This central registry lists all personal data processing activities carried out at the VU. The registry indicates why and how personal data are processed, and with whom they are shared. The registry helps the VU demonstrate compliance with the GDPR and in the case of a data breach, the registry helps with monitoring and acting swiftly to inform all relevant stakeholders.
 
 For research projects, the VU registers data processing via [DMPonline](https://dmponline.vu.nl/). You can create your registration by logging into DMPonline and following the following instructions:
 
@@ -76,7 +75,7 @@ If you use personal data in your research, you should register your data process
 
 ## What is data
 
-Research data is any information that has been collected, observed, generated or created to validate original research findings. Examples of data could be interview recordings, experiment results, physical measurement, notes from focus group's meetings, notes from fieldwork, observations captured in photographs, film or audio, text files extracted from a corpus, image of archival items or artworks, scraped websites, responses to survey questions.  Algorithms, simulations, code, scripts and software are often also considered as research data. There is also physical data: (biological) samples, collections, artifacts etc. 
+Research data is any information that has been collected, observed, generated or created to validate original research findings. Examples of data could be interview recordings, experiment results, physical measurement, notes from focus group's meetings, notes from fieldwork, observations captured in photographs, film or audio, text files extracted from a corpus, image of archival items or artworks, scraped websites, responses to survey questions.  Algorithms, simulations, code, scripts and software are often also considered as research data. There is also physical data: (biological) samples, collections, artifacts etc.
 
 Administrative documents, like informed consent forms and key files should be acknowledged as important elements of research data as well.  
 


### PR DESCRIPTION
This PR moves the hyperlink from the heading into the text, and removes the note for ourselves.

Fixes #25.