### PR TITLE
Remove GDPR heading

### DIFF
--- a/chapters/data-management-plan.qmd
+++ b/chapters/data-management-plan.qmd
@@ -30,8 +30,6 @@ Note: Follow these steps as well if you receive funding from NWO or ZonMw (see a
 
 ![](../public/dmp-001.png)
 
-### GDPR registration form
-
 If you're aiming to write a full DMP based on the VU DMP template, please make sure you don't select the GDPR registration form. 
 
 ![](../public/dmp-002.png)


### PR DESCRIPTION
As @jhrudey indicated, the heading in the template section was potentially a bit much as it only contains one sentence.

This PR removes that heading and retains the rest of the contents.

Fixes #24.