### PR TITLE
Add `About` page

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -1,0 +1,34 @@
+name: Collect contributors
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 8 * * 1'
+
+jobs:
+    run-r-script:
+        runs-on: ubuntu-latest
+        env:
+            GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+            - name: Setup R
+              uses: r-lib/actions/setup-r@v2
+
+            - uses: r-lib/actions/setup-r-dependencies@v2
+              with:
+                packages: |
+                    gh
+                    allcontributors
+
+            - name: Collect contributor data
+              run: Rscript -e 'allcontributors::add_contributors(files = c("about.qmd", "README.md"), num_sections = 1, alphabetical = TRUE)'
+            - uses: EndBug/add-and-commit@v9
+              with:
+                default_author: github_actions
+                message: "Update contributors"
+                add: 'README.md about.qmd'

--- a/README.md
+++ b/README.md
@@ -30,3 +30,54 @@ quarto publish gh-pages
 ```
 
 If you like commandlines and need to install Quarto, [check out the Quarto website](https://quarto.org/docs/get-started/index.html) for more info.
+
+## Contributors
+
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+All contributions to this project are gratefully acknowledged using the [`allcontributors` package](https://github.com/ropenscilabs/allcontributors) following the [all-contributors](https://allcontributors.org) specification. Contributions of any kind are welcome!
+
+<table>
+
+<tr>
+<td align="center">
+<a href="https://github.com/chartgerink">
+<img src="https://avatars.githubusercontent.com/u/2946344?v=4" width="100px;" alt=""/>
+</a><br>
+<a href="https://github.com/ubvu/open-handbook/commits?author=chartgerink">chartgerink</a>
+</td>
+<td align="center">
+<a href="https://github.com/Jolien-S">
+<img src="https://avatars.githubusercontent.com/u/142608800?v=4" width="100px;" alt=""/>
+</a><br>
+<a href="https://github.com/ubvu/open-handbook/commits?author=Jolien-S">Jolien-S</a>
+</td>
+<td align="center">
+<a href="https://github.com/Elisa-on-GitHub">
+<img src="https://avatars.githubusercontent.com/u/78543806?v=4" width="100px;" alt=""/>
+</a><br>
+<a href="https://github.com/ubvu/open-handbook/commits?author=Elisa-on-GitHub">Elisa-on-GitHub</a>
+</td>
+<td align="center">
+<a href="https://github.com/Karvovskaya">
+<img src="https://avatars.githubusercontent.com/u/44666630?v=4" width="100px;" alt=""/>
+</a><br>
+<a href="https://github.com/ubvu/open-handbook/commits?author=Karvovskaya">Karvovskaya</a>
+</td>
+<td align="center">
+<a href="https://github.com/jhrudey">
+<img src="https://avatars.githubusercontent.com/u/35424147?v=4" width="100px;" alt=""/>
+</a><br>
+<a href="https://github.com/ubvu/open-handbook/commits?author=jhrudey">jhrudey</a>
+</td>
+</tr>
+
+</table>
+
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+

--- a/about.qmd
+++ b/about.qmd
@@ -14,7 +14,9 @@ Previously such resources were spread out across many different pages at the VU 
 
 The Open Handbook was initiated by Lena Karvovskaya, Jessica Hrudey, Elisa, and Jolien Scholten. The initial infrastructure for the Open Handbook was built by Liberate Science.
 
-<!-- We want to specifically call out the following folk for contributing outside of GitHub: -->
+We want to specifically call out the following folk who contributed outside of GitHub:
+
+* Jochem Lybaart
 
 ### GitHub contributors 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->

--- a/about.qmd
+++ b/about.qmd
@@ -1,3 +1,7 @@
+---
+toc: false
+---
+
 # About
 
 The Open Handbook is a project started by Research Data Support in early 2024. After planning and design phases, we launched the initial version of the resource at the Research Support Days in May 2024.
@@ -8,13 +12,11 @@ Previously such resources were spread out across many different pages at the VU 
 
 ## Contributors
 
-The Open Handbook was initiated by Lena Karvovskaya, Jessica Hrudey, Elisa, and Jolien Scholten.
+The Open Handbook was initiated by Lena Karvovskaya, Jessica Hrudey, Elisa, and Jolien Scholten. The initial infrastructure for the Open Handbook was built by Liberate Science.
 
-People participate in different ways and all those contributions are appreciated 🙏 
 <!-- We want to specifically call out the following folk for contributing outside of GitHub: -->
 
-Below you can find all the contributors who participated on GitHub.
-
+### GitHub contributors 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->

--- a/about.qmd
+++ b/about.qmd
@@ -1,0 +1,63 @@
+# About
+
+The Open Handbook is a project started by Research Data Support in early 2024. After planning and design phases, we launched the initial version of the resource at the Research Support Days in May 2024.
+
+The Open Handbook centralizes resources that VU researchers need to do their work. The Open Handbook also provides everyone with direct pathways to change resources in case anything has become outdated.
+
+Previously such resources were spread out across many different pages at the VU and were hard to update. The Open Handbook is curated by us all, and reviewed by specialists. This way we can help each other.
+
+## Contributors
+
+The Open Handbook was initiated by Lena Karvovskaya, Jessica Hrudey, Elisa, and Jolien Scholten.
+
+People participate in different ways and all those contributions are appreciated 🙏 
+<!-- We want to specifically call out the following folk for contributing outside of GitHub: -->
+
+Below you can find all the contributors who participated on GitHub.
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+All contributions to this project are gratefully acknowledged using the [`allcontributors` package](https://github.com/ropenscilabs/allcontributors) following the [all-contributors](https://allcontributors.org) specification. Contributions of any kind are welcome!
+
+<table>
+
+<tr>
+<td align="center">
+<a href="https://github.com/chartgerink">
+<img src="https://avatars.githubusercontent.com/u/2946344?v=4" width="100px;" alt=""/>
+</a><br>
+<a href="https://github.com/ubvu/open-handbook/commits?author=chartgerink">chartgerink</a>
+</td>
+<td align="center">
+<a href="https://github.com/Jolien-S">
+<img src="https://avatars.githubusercontent.com/u/142608800?v=4" width="100px;" alt=""/>
+</a><br>
+<a href="https://github.com/ubvu/open-handbook/commits?author=Jolien-S">Jolien-S</a>
+</td>
+<td align="center">
+<a href="https://github.com/Elisa-on-GitHub">
+<img src="https://avatars.githubusercontent.com/u/78543806?v=4" width="100px;" alt=""/>
+</a><br>
+<a href="https://github.com/ubvu/open-handbook/commits?author=Elisa-on-GitHub">Elisa-on-GitHub</a>
+</td>
+<td align="center">
+<a href="https://github.com/Karvovskaya">
+<img src="https://avatars.githubusercontent.com/u/44666630?v=4" width="100px;" alt=""/>
+</a><br>
+<a href="https://github.com/ubvu/open-handbook/commits?author=Karvovskaya">Karvovskaya</a>
+</td>
+<td align="center">
+<a href="https://github.com/jhrudey">
+<img src="https://avatars.githubusercontent.com/u/35424147?v=4" width="100px;" alt=""/>
+</a><br>
+<a href="https://github.com/ubvu/open-handbook/commits?author=jhrudey">jhrudey</a>
+</td>
+</tr>
+
+</table>
+
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->


### PR DESCRIPTION
This PR adds the About page.

Specifically:
* A GitHub action workflow that runs every Monday at 8AM to update the GitHub contributors
* A short (draft) history of the project

Fixes #28.