### PR TITLE
Remove license page reference

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -50,8 +50,6 @@ website:
         href: about.qmd
       - text: "FAQ"
         href: docs/faq/index.qmd
-      - text: "License"
-        href: license.qmd
     right:
       - text: "By VU & Liberate Science GmbH"
 


### PR DESCRIPTION
This PR removes the license page reference in the footer. We already indicate the license in the footer itself, and at this time there is no clear need for an additional license page.

Fixes #30.
