### PR TITLE
Add trainings topic

### DIFF
--- a/topics/trainings.qmd
+++ b/topics/trainings.qmd
@@ -67,7 +67,7 @@ The Open Science Horror Escape Room was made for the Data Horror week 2021.
 
 - URL: <https://doi.org/10.5281/zenodo.6963493>
 - Licence: CC-BY-4.0
-- Topics: Open science, Escape room, Workshop, Open access, Research data management, FAIR,
+- Topics: Open science, Escape room, Workshop, Open access, Research data management, FAIR
 - Target audience: Everybody
 - Status: Active
 - Duration: 30-60 minutes
@@ -121,7 +121,6 @@ The OSF is an open-source project management tool that supports researchers thro
 ---
 
 - URL: <https://osf.io/ab923/>
-- Licence:
 - Topics: OSF, Preprint, Publishing, Archiving, RDM tools, Data management
 - Target audience: Everybody
 - Status: Bi-annually during the Support Training Days
@@ -181,14 +180,13 @@ The lessons are designed for programming beginners and do not require any experi
 ---
 
 - URL: <https://software-carpentry.org/lessons/>
-- Licence:
 - Topics: Coding, Software skills, Python, R, Bash, Unix Shell, Git, GitHub, Version control
 - Target audience: Researchers, students
 - Status: Available on set moments
 - Duration: 28 hours over four days
 - Online/in-person: In-person and online (self-study)
 
----
+<!-- ---
 
 ## Writing a Data Management Plan
 
@@ -203,4 +201,4 @@ The course consists of 2 online workshops and an online peer review session. Ple
 - Target audience: Researchers, PhD
 - Status: Available on set moments
 - Duration: 60 minutes
-- Online/in-person: Online
+- Online/in-person: Online -->

--- a/topics/trainings.qmd
+++ b/topics/trainings.qmd
@@ -17,6 +17,8 @@ Do you want to meet other researchers, improve your programming skills, or ask q
 - Duration: 120 minutes
 - Online/in-person: In-person
 
+---
+
 ## Data Analysis with R --- Data Carpentry workshop for programming beginners
 
 Are you analysing tabular data in your research? Would you like to learn how to use the programming language R to make your work more effective and efficient? This workshop is for absolute programming beginners and introduces basic steps for the analysis and visualization of tabular data with R Studio. You will:
@@ -34,6 +36,8 @@ Are you analysing tabular data in your research? Would you like to learn how to 
 - Duration: 28 hours over four days
 - Online/in-person: In-person and online (self-study)
 
+---
+
 ## Escape Room: Data Horror
 
 Resolve the data horror of professor Hutseephluts and secure the grant! This online escape room challenges everyone to tackle the horrors of research data management. Will you be able to escape within an hour?
@@ -49,6 +53,8 @@ The Data Horror Escape Room was made for the Data Horror week 2020.
 - Status: Active
 - Duration: 60 minutes
 - Online/in-person: Online
+
+---
 
 ## Escape Room: Open Science Horror
 
@@ -67,6 +73,8 @@ The Open Science Horror Escape Room was made for the Data Horror week 2021.
 - Duration: 30-60 minutes
 - Online/in-person: Online
 
+---
+
 ## Escape Room: Software Horror
 
 The only thing between you and certain doom --- getting your software management in order! This online escape room challenges everyone to tackle the horrors of software management and open software publishing.
@@ -84,6 +92,8 @@ The Software Horror Escape Room was made for the Data Horror week 2022.
 - Duration: 60 minutes
 - Online/in-person: Online
 
+---
+
 ## Lego Workshop
 
 This workshop offers a hands-on experience in the importance of careful documentation during research. Participants will discover the pitfalls in communicating research progress through written media. This offers a fun introduction in writing well structured contextual metadata such as research logs, protocols, machine settings and general `README` files.
@@ -99,6 +109,8 @@ The data package offers a powerpoint and general guidelines in hosting the works
 - Status: Active
 - Duration: 30-90 minutes
 - Online/in-person: In-person
+
+---
 
 ## Open Science Framework (OSF) Workshop
 
@@ -116,6 +128,8 @@ The OSF is an open-source project management tool that supports researchers thro
 - Duration: 120 minutes
 - Online/in-person: Online
 
+---
+
 ## Open Science against Humanity
 
 This card game is based on "Cards Against Humanity" and teaches basic concepts of Open Science, Research Data Management, Software Management, FAIR principles, and Research Ethics in a fun and entertaining way. The white cards describe research related situations or statements relevant for researchers. The black cards contain potential answers or prompts that have a connection to Open Science. The goal of the game is to pair the white cards (prompts) and the black cards in the funniest, most provocative, or smartest way you can. Playing the card game online or with a physical deck creates awareness of issues around resesarch practices and allows for discussions around Open Science.
@@ -129,6 +143,8 @@ This card game is based on "Cards Against Humanity" and teaches basic concepts o
 - Status: Active
 - Duration: 30-60 minutes
 - Online/in-person: Online and in-person
+
+---
 
 ## Open loves Science
 
@@ -147,6 +163,8 @@ In Open loves Science, players are invited to engage in playful and deep convers
 - Status: Active
 - Duration: 30-60 minutes
 - Online/in-person: Online and in-person
+
+---
 
 ## Software Carpentries
 
@@ -169,6 +187,8 @@ The lessons are designed for programming beginners and do not require any experi
 - Status: Available on set moments
 - Duration: 28 hours over four days
 - Online/in-person: In-person and online (self-study)
+
+---
 
 ## Writing a Data Management Plan
 

--- a/topics/trainings.qmd
+++ b/topics/trainings.qmd
@@ -1,0 +1,186 @@
+---
+title: Trainings
+---
+
+It is easy to get overwhelmed with all the trainings available. On this page we provide a list of trainings available.
+
+## Bytes and Bites
+
+Do you want to meet other researchers, improve your programming skills, or ask questions related to programming? Pick up your laptop and come to **Bytes & Bites**. We're back in full swing for another edition of our coding cafe **Bytes & Bites**. At **Bytes & Bites** anyone is welcome, whether you are a beginner or advanced programmer, whether you write in R or in C++. And of course, you can't program and work with "Bytes" without any tasty "Bites"! We'll make sure there is pizza or snacks available!
+
+---
+
+- URL: <https://ubvu.github.io/bytes-and-bites/>
+- Topics: Programming, Python, R, Community, Software, Coding
+- Target audience: everybody
+- Status: Monthly
+- Duration: 120 minutes
+- Online/in-person: In-person
+
+## Data Analysis with R --- Data Carpentry workshop for programming beginners
+
+Are you analysing tabular data in your research? Would you like to learn how to use the programming language R to make your work more effective and efficient? This workshop is for absolute programming beginners and introduces basic steps for the analysis and visualization of tabular data with R Studio. You will:
+
+- Organize tabular data, handle date formatting, carry out quality control and quality assurance and export data to use with downstream applications.
+- Explore, summarize, and clean tabular data reproducibly.
+- Import data, calculate summary statistics, and create publication-quality graphics using the programming language R
+
+---
+
+- URL: <https://datacarpentry.org/lessons/#social-science-curriculum>
+- Topics: Software skills, Data analysis, Plotting, R, OpenRefine, Spreadsheets
+- Target audience: Researchers, students
+- Status: Available on set moments
+- Duration: 28 hours over four days
+- Online/in-person: In-person and online (self-study)
+
+## Escape Room: Data Horror
+
+Resolve the data horror of professor Hutseephluts and secure the grant! This online escape room challenges everyone to tackle the horrors of research data management. Will you be able to escape within an hour?
+
+The Data Horror Escape Room was made for the Data Horror week 2020.
+
+---
+
+- URL: <https://doi.org/10.5281/zenodo.6949510>
+- Licence: CC-BY-SA-4.0
+- Topics: Research data, Escape room, Workshop, Data management, Research data management, FAIR
+- Target audience: Everybody
+- Status: Active
+- Duration: 60 minutes
+- Online/in-person: Online
+
+## Escape Room: Open Science Horror
+
+Help the cyborgs by publishing their code the right way --- the open science way! This online escape room challenges everyone to tackle the horrors of open science and open access publishing. Will you be able to
+save the cyborgs and finally get a coffee?
+
+The Open Science Horror Escape Room was made for the Data Horror week 2021.
+
+---
+
+- URL: <https://doi.org/10.5281/zenodo.6963493>
+- Licence: CC-BY-4.0
+- Topics: Open science, Escape room, Workshop, Open access, Research data management, FAIR,
+- Target audience: Everybody
+- Status: Active
+- Duration: 30-60 minutes
+- Online/in-person: Online
+
+## Escape Room: Software Horror
+
+The only thing between you and certain doom --- getting your software management in order! This online escape room challenges everyone to tackle the horrors of software management and open software publishing.
+Will you be able to save your own soul and publish in Frontiers in Hell?
+
+The Software Horror Escape Room was made for the Data Horror week 2022.
+
+---
+
+- URL: <https://doi.org/10.5281/zenodo.7350527>
+- Licence: CC-BY-4.0
+- Topics: Software management, Escape room, Workshop, Software, Research data management, FAIR,
+- Target audience: Everybody
+- Status: Active
+- Duration: 60 minutes
+- Online/in-person: Online
+
+## Lego Workshop
+
+This workshop offers a hands-on experience in the importance of careful documentation during research. Participants will discover the pitfalls in communicating research progress through written media. This offers a fun introduction in writing well structured contextual metadata such as research logs, protocols, machine settings and general `README` files.
+
+The data package offers a powerpoint and general guidelines in hosting the workshop.
+
+---
+
+- URL: <https://doi.org/10.5281/zenodo.10174000>
+- Licence: CC-BY-4.0
+- Topics: Metadata, Contextual metadata, LEGO, Workshop
+- Target audience: Researchers
+- Status: Active
+- Duration: 30-90 minutes
+- Online/in-person: In-person
+
+## Open Science Framework (OSF) Workshop
+
+This is a hands-on course to get started with the Open Science Framework (OSF). You won't need any experience with the tool beforehand. We will show the differences and similarities between OSF and other tools at the VU (such as Yoda). We will make a preregistration of a (mock) OSF research.
+
+The OSF is an open-source project management tool that supports researchers throughout their entire project lifecycle. As a collaboration tool, OSF helps research teams work on projects privately or make the whole project publicly accessible for broad dissemination. As a workflow system, OSF enables connections to the many scientific tools researchers already use, streamlining their process and increasing efficiency. You may even use OSF as a portfolio tool for sharing your work as a prepublication with potential collaborators.
+
+---
+
+- URL: <https://osf.io/ab923/>
+- Licence:
+- Topics: OSF, Preprint, Publishing, Archiving, RDM tools, Data management
+- Target audience: Everybody
+- Status: Bi-annually during the Support Training Days
+- Duration: 120 minutes
+- Online/in-person: Online
+
+## Open Science against Humanity
+
+This card game is based on "Cards Against Humanity" and teaches basic concepts of Open Science, Research Data Management, Software Management, FAIR principles, and Research Ethics in a fun and entertaining way. The white cards describe research related situations or statements relevant for researchers. The black cards contain potential answers or prompts that have a connection to Open Science. The goal of the game is to pair the white cards (prompts) and the black cards in the funniest, most provocative, or smartest way you can. Playing the card game online or with a physical deck creates awareness of issues around resesarch practices and allows for discussions around Open Science.
+
+---
+
+- URL: <https://doi.org/10.5281/zenodo.10017280>
+- Licence: CC-BY-4.0
+- Topics: Open science, Card game, Workshop, Game, Research data management, FAIR, Software management
+- Target audience: Everybody (familiar with academics)
+- Status: Active
+- Duration: 30-60 minutes
+- Online/in-person: Online and in-person
+
+## Open loves Science
+
+Open Science aims to improve, streamline and elevate science to something bigger. Why? Out of love for science of course!
+
+In Open loves Science, players are invited to engage in playful and deep conversations about Open Science. The card game features an encyclopedia of issues that pervade this movement of research reform and ask participants to consider their role and values in changing academic culture. Like Open Science, this game is about connection. Players are meant to look into each other's eyes, engage in conversation, and better understand one another.
+
+"Open loves Science" was made for the Data love week 2024.
+
+---
+
+- URL: <https://nlesc.github.io/open-loves-science/>
+- Licence: CC-BY-4.0
+- Topics: Open science, Card game, Workshop, Game, Research data management, FAIR, Software management
+- Target audience: Everybody
+- Status: Active
+- Duration: 30-60 minutes
+- Online/in-person: Online and in-person
+
+## Software Carpentries
+
+The Software Carpentries are hands-on workshops that teach basic skills needed to program in a reproducible way.
+
+A Software Carpentry workshop covers lessons on:
+
+- Plotting and Programming in Python or R
+- The Unix Shell
+- Version Control with Git and GitHub
+
+The lessons are designed for programming beginners and do not require any experience. You program along, learn by helping one another, and apply what you have learned in exercises.
+
+---
+
+- URL: <https://software-carpentry.org/lessons/>
+- Licence:
+- Topics: Coding, Software skills, Python, R, Bash, Unix Shell, Git, GitHub, Version control
+- Target audience: Researchers, students
+- Status: Available on set moments
+- Duration: 28 hours over four days
+- Online/in-person: In-person and online (self-study)
+
+## Writing a Data Management Plan
+
+In this course you learn how you write a good Data Management Plan (DMP) for your research project. The course is aimed at PhD students at the beginning of their research project.
+
+The course consists of 2 online workshops and an online peer review session. Please make sure that you are able to participate in all three events.
+
+---
+
+- URL:
+- Topics:
+- Target audience: Researchers, PhD
+- Status: Available on set moments
+- Duration: 60 minutes
+- Online/in-person: Online


### PR DESCRIPTION
This PR adds the "Trainings" topic that provides a list of trainings. This list was provided by Tycho Hofstra and Stephanie van de Sandt.

I adjusted "Keywords" to "Topics" as keywords do not exist in the handbook as such. Topics is more informative to tell readers what related topics are discussed. We can add hyperlinks to the relevant topics or identify additional topics to write about. 
