### PR TITLE
Add Editors guide

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -42,6 +42,7 @@ website:
     center:
       - text: "About"
         href: about.qmd
+      - href: editors-guide.qmd
       # - text: "FAQ"
       #   href: docs/faq/index.qmd
     right:

--- a/editors-guide.qmd
+++ b/editors-guide.qmd
@@ -1,0 +1,37 @@
+---
+title: "Editor's guide"
+---
+
+Welcome to the Editor's guide to the Handbook. This page contains resources around how the editors work. We make this open so you can see how it works behind the scenes.
+
+## Deleting branches
+
+After merging Pull Requests, it is expected to clean up the branch by deleting it. We enable auto deletion upon merging, but if that for some reason does not happen, please go ahead and "Delete branch"
+
+## Netlify
+
+Netlify is a hosting service, where the files for the website live. This means that even though we create the website on GitHub, Netlify is where the website is hosted. When GitHub is down, the website should be unaffected.
+
+## Pull Request handling
+
+We maintain strict standards for the content included in the Research Support Handbook. Below we expand on the norms we maintain to merge and close pull requests.
+
+### Merging pull requests
+
+We maintain a set of rules to ensure content does not get included prematurely:
+
+- At least one editor needs to approve the pull request
+- All discussions in the pull request need to be marked as resolved
+- All automated quality checks need to be successful
+
+All three criteria have to be met for successful inclusion in the Research Support Handbook. Note that any approvals are voided when someone adds additional changes. A new review will have to be provided at that time.
+
+A more implicit norm is that we provide at least 24 hours for people to review, even if the first editor reviews within the first hour. As such, everyone knows they have at least 24 hours to take a look at the content.
+
+### Closing pull requests
+
+Not all pull requests make it into the handbook, and that is okay. We want to ensure that pull requests are not closed at random, and provide some norms around doing so.
+
+Stale pull requests can be closed with a note for the contributor that they are welcome to request the pull request to be re-opened. We automatically mark pull requests as stale after 30 days.
+
+Pull requests that provide too much discussion and do not have a pathway to resolution may be closed for being disputed. This does not mean the content goes to waste – here we recommend an issue to be opened to continue the discussion. Please note that disputed topics can only be carried on if done so in a mutually constructive manner. 


### PR DESCRIPTION
This PR adds an initial Editor's guide, as proposed in #39. This PR does not attempt to be complete in terms of what the editor's guide is supposed to be, but to provide an initial page that we can keep expanding on as new points come up. I tried to capture some parts, but am surely missing elements. I am happy to add whatever gets suggested in this PR.

Fixes #39.

The Editor's guide is linked to from the footer of the page, next to the "About" button.
