### PR TITLE
Create data-management-section

### DIFF
--- a/data-management-section
+++ b/data-management-section
@@ -1,0 +1,10 @@
+# Data Management Section
+
+Many funders require researchers to include a section in their project proposal about Research Data Management, in which they explain whether existing data will be reused, whether new data will be collected or generated during the project, and how they plan to structure, archive and share their data. Depending on requirements of the funder, the paragraph can be short or more extensive.
+
+Funders may have different requirements for the data management section in the project proposal. Always check what your funder asks for. Below is a list of information on data management sections from main Dutch funding bodies.
+
+- [NWO](https://www.nwo.nl/en/research-data-management)
+- [ZonMw] (https://www.zonmw.nl/en/instructions-fair-data-management-grant-applicants)
+
+We recommend you to ask advice from the [RDM Support Desk](rdm@vu.nl) when writing your data management section.

--- a/topics/data-management-section.qmd
+++ b/topics/data-management-section.qmd
@@ -1,4 +1,6 @@
-# Data Management Section
+---
+title: Data Management Section
+---
 
 Many funders require researchers to include a section in their project proposal about Research Data Management, in which they explain whether existing data will be reused, whether new data will be collected or generated during the project, and how they plan to structure, archive and share their data. Depending on requirements of the funder, the paragraph can be short or more extensive.
 

--- a/topics/data-management-section.qmd
+++ b/topics/data-management-section.qmd
@@ -7,6 +7,6 @@ Many funders require researchers to include a section in their project proposal 
 Funders may have different requirements for the data management section in the project proposal. Always check what your funder asks for. Below is a list of information on data management sections from main Dutch funding bodies.
 
 - [NWO](https://www.nwo.nl/en/research-data-management)
-- [ZonMw] (https://www.zonmw.nl/en/instructions-fair-data-management-grant-applicants)
+- [ZonMw](https://www.zonmw.nl/en/instructions-fair-data-management-grant-applicants)
 
 We recommend you to ask advice from the [RDM Support Desk](rdm@vu.nl) when writing your data management section.


### PR DESCRIPTION
- I took the information about data management paragraphs out of the pathway 'Plan & Design'
- I renamed 'data management paragraph' to 'data management section', as this seems to be more in line with current funder terminology
- I removed the questions from NWO; they were outdated and including specific questions runs the risk of becoming outdated again soon
- In included links to information from NWO and ZonMw; ERC/Horizon Europe don't ask for a data management section, I believe; if someone has useful additional links, please add.