### PR TITLE
improve HPC part

### DIFF
--- a/pathways/process-and-analyze.qmd
+++ b/pathways/process-and-analyze.qmd
@@ -128,7 +128,7 @@ BAZIS also has several "community" nodes for use by all VU researchers, sponsore
 BAZIS is connected to SciStor <!--# needs internal link --> providing easy access to your research data and analysis result. 
 
 #### VU JupyterHub for education 
-If you are not yet ready to take the leap to cluster computing and work with Python consider JupyterHub. VU IT has built a Jupyter Notebook environment meant mainly for Education purposes, but accessible for researchers as well on [https://hub.compute.vu.nl/](https://hub.compute.vu.nl/)
+If you are not yet ready to take the leap to cluster computing and work with Python consider JupyterHub. VU IT has built a Jupyter Notebook environment meant mainly for Education purposes, but accessible for researchers as well on <https://hub.compute.vu.nl/>
 
 #### (Virtual) servers
 There are also several options to run applications in a server environment. This is useful if for example you use software that does not work on HPC, you want to run a web service, you want to create a research environment for your project. There are several options available for researchers.

--- a/pathways/process-and-analyze.qmd
+++ b/pathways/process-and-analyze.qmd
@@ -102,37 +102,42 @@ The VU has several research groups that offer their code online. You can find th
 * VU RDM Tech IT group, on [GitHub](https://github.com/vu-rdm-tech)
 * A list of RDM tools, on [GitHub](https://htmlpreview.github.io/?https://github.com/vu-rdm-tech/api-scripts/blob/master/tool_descriptions/doctext.html)
 
-## High performance computing
-
+### Compute services
+<!--# I'm thinking this might also be worh its own topic page -->
 If your pc or laptop takes too much time performing your analysis, it is time to scale up to a higher level. There are several options for employees and students who require more computing power than their own desktop or laptop can provide.
 
+Several options are detailed below. [Contact IT for Research](https://services.vu.nl/esc?id=sc_cat_item&sys_id=4e079166978d5950e553359fe153afc5) for advice on which solution could best fit your workflow
+
+#### High Performance Computing
 ![](https://libapps-eu.s3.amazonaws.com/accounts/46351/images/noaa-ibmsupercomputer.gif)
 
-### When do you need access to High Performance Computing?
+Roughly speaking, you should try to get access to the HPC when you need to stick a post-it on your laptop or PC that says: "do not touch, analysis ongoing". Or when you want to run analyses parallel to each other, because they take too long. It is important to consider such a situation at the very beginning of your research or when writing your Data Management Plan: is it conceivable that your dataset will become so large or your analysis so complicated that you will need HPC? Please note that this can occur for any discipline and any sort of data, qualitative and quantitative. If you may need HPC, you also need to reconsider your analysis methods. Programmes like SPSS and Excel do not run well on a HPC, and you would need to (learn to) write scripts in R or Python <!-- # [R or Python](https://libguides.vu.nl/rdm/data-analysis) -->. If you want to know if using HPC may be necessary or useful for your project, you can contact [IT for Research](https://services.vu.nl/esc?id=sc_cat_item&sys_id=4e079166978d5950e553359fe153afc5) to ask for more information (select the "Onderzoek service domain").
 
-Roughly speaking, you should try to get access to the HPC when you need to stick a post-it on your laptop or PC that says: "do not touch, analysis ongoing". Or when you want to run analyses parallel to each other, because they take too long. It is important to consider such a situation at the very beginning of your research or when writing your Data Management Plan: is it conceivable that your dataset will become so large or your analysis so complicated that you will need HPC? Please note that this can occur for any discipline and any sort of data, qualitative and quantitative. If you may need HPC, you also need to reconsider your analysis methods. Programmes like SPSS and Excel do not run well on a HPC, and you would need to (learn to) write scripts in [R or Python](https://libguides.vu.nl/rdm/data-analysis). If you want to know if using HPC may be necessary or useful for your project, you can contact [IT for Research](https://services.vu.nl/esc?id=emp_taxonomy_topic&topic_id=4cb138ee97fa0950e553359fe153afff) to ask for more information.
+#### SURF Snellius Compute Cluster
+Snellius is the Dutch National supercomputer hosted at SURF. The system facilitates scientific research carried out in many Universities, independent research institutes, governmental organizations, and private companies in the Netherlands.  
 
-#### SURF Lisa Compute Cluster:
+It’s a service comprising a wide range of resources, compilers and, such as R statistics and MATLAB, and libraries. SURF continually adjusts the service to the needs of the user community. For example, Snellius Compute Cluster includes accelerators (very fast processors),high memory nodes and GPU nodes. <!--# might need a further rewrite -->
 
-[Lisa Compute Cluster](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0012774) is a centrally managed Linux cluster, that is ideal for large-scale computations. It’s a service comprising a wide range of resources, compilers and [**software**](https://userinfo.surfsara.nl/systems/lisa/software), such as R statistics and MATLAB, and libraries, such as the Math Kernel Library (MKL) or Intel. SURFsara continually adjusts the service to the needs of the user community. For example, Lisa Compute Cluster includes accelerators (very fast processors) and high memory nodes (for users who need nodes with extra memory). When processing batch jobs, SURFsara applies a ‘fair share’ mechanism.
+You can find more information on the [SURF Snellius Wiki](https://servicedesk.surf.nl/wiki/display/WIKI/Snellius).
 
 #### BAZIS Compute Cluster
+IT for Research (ITvO) offers access to your own Linux computational cluster at the VU. BAZIS is a managed service for high performance computing (HPC). Research groups can add their own compute server hardware to [BAZIS](../topics/bazis.qmd), ITvO will take care of configuring and maintaining the software stack on your servers.
 
-IT for Research (ITvO) offers access to your own Linux computational cluster at the VU.[BAZIS](https://services.vu.nl/esc?id=emp_taxonomy_topic&topic_id=68b9e61f97cf09d0e553359fe153af51) is a managed service for high performance computing (HPC). Research groups can add their own compute servers to BAZIS and directly use software and options that are usually only available on a supercomputer. BAZIS also has 7 GPU nodes with 240GB memory and 32 cores for general use, sponsored by the VU HPC Counsel. Compute results are stored in Scistor and can be directly available on your own workstation for further analysis.
+BAZIS also has several "community" nodes for use by all VU researchers, sponsored by the VU HPC Council. 
 
-#### SURF RCCS
+BAZIS is connected to SciStor <!--# needs internal link --> providing easy access to your research data and analysis result. 
 
-[SURF Research Capacity Computing Service](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0012777) (RCCS) further extends the solutions available with the on-premise Bazis cluster and SURF Lisa CPU cluster with:  
+#### VU JupyterHub for education 
+If you are not yet ready to take the leap to cluster computing and work with Python consider JupyterHub. VU IT has built a Jupyter Notebook environment meant mainly for Education purposes, but accessible for researchers as well on [https://hub.compute.vu.nl/](https://hub.compute.vu.nl/)
 
-* Access to [Lisa GPU island](https://www.surf.nl/en/lisa-compute-cluster-extra-processing-power-for-research)  
-* Access to the [National Supercomputer Snellius](https://www.surf.nl/en/dutch-national-supercomputer-snellius) at SURF  
-* Access to [SURF HPC Cloud](https://www.surf.nl/en/hpc-cloud-your-flexible-compute-infrastructure)  
-* Project space on SURF systems  
+#### (Virtual) servers
+There are also several options to run applications in a server environment. This is useful if for example you use software that does not work on HPC, you want to run a web service, you want to create a research environment for your project. There are several options available for researchers.
 
-Watch [this youtube video](https://youtu.be/z0dWGmFRjLs) for detailed information.
+##### SciCloud
+IT for Research (ITvO) offers a virtual server environment where you can run your own server (Linux or Windows). ITvO installs the basic operating system and you are free to install needed software. Web services can be made accessible on the internet. You can find more information and a request form on the [VU service portal](https://services.vu.nl/esc?id=emp_taxonomy_topic&topic_id=d80aee1f97cf09d0e553359fe153afd7)
 
-To help you to efficiently use scientific software on your workstation or compute cluster there are regular training possibilities. Check in your department, at [https://hpc.labs.vu.nl](https://hpc.labs.vu.nl) or [https://training.prace-ri.eu/](https://training.prace-ri.eu/)
+##### SURF Research Cloud
+SURF also offers a virtual server environment. Several environments with pre-installed software can easily be installed from a catalog. Find more information on the (SURF wiki)[https://servicedesk.surf.nl/wiki/display/WIKI/SURF+Research+Cloud] 
 
-Please contact the [IT for Research department](https://services.vu.nl/esc?id=emp_taxonomy_topic&topic_id=4cb138ee97fa0950e553359fe153afff) in order to discuss your possibilities.
-
-For every step of your data analysis, good [documentation](http://libguides.vu.nl/rdm/data-documentation) is necessary.
+##### Dedicated hardware 
+Sometimes your workload needs dedicated hardware. ITvO offers the option to host your own server hardware in our on-campus data center. Please [Contact IT for Research](https://services.vu.nl/esc?id=sc_cat_item&sys_id=4e079166978d5950e553359fe153afc5) to discuss possibilities.

--- a/pathways/process-and-analyze.qmd
+++ b/pathways/process-and-analyze.qmd
@@ -108,7 +108,7 @@ If your pc or laptop takes too much time performing your analysis, it is time to
 
 Several options are detailed below. [Contact IT for Research](https://services.vu.nl/esc?id=sc_cat_item&sys_id=4e079166978d5950e553359fe153afc5) for advice on which solution could best fit your workflow
 
-#### High Performance Computing
+#### High Performance Computing (HPC)
 ![](https://libapps-eu.s3.amazonaws.com/accounts/46351/images/noaa-ibmsupercomputer.gif)
 
 Roughly speaking, you should try to get access to the HPC when you need to stick a post-it on your laptop or PC that says: "do not touch, analysis ongoing". Or when you want to run analyses parallel to each other, because they take too long. It is important to consider such a situation at the very beginning of your research or when writing your Data Management Plan: is it conceivable that your dataset will become so large or your analysis so complicated that you will need HPC? Please note that this can occur for any discipline and any sort of data, qualitative and quantitative. If you may need HPC, you also need to reconsider your analysis methods. Programmes like SPSS and Excel do not run well on a HPC, and you would need to (learn to) write scripts in R or Python <!-- # [R or Python](https://libguides.vu.nl/rdm/data-analysis) -->. If you want to know if using HPC may be necessary or useful for your project, you can contact [IT for Research](https://services.vu.nl/esc?id=sc_cat_item&sys_id=4e079166978d5950e553359fe153afc5) to ask for more information (select the "Onderzoek service domain").


### PR DESCRIPTION
There was a lot of ourdated information in the HPC part, I've tried to improve that:
- Removed info on Lisa (service no longer available, it's just Snellius now)
- Added Snellius info
- Removed RCCS. RCCS this is the set of agreements and contracts we have with SURF about access to their compute services, does not really belong here.
- Added Jupyterhub and a few server hosting options
- I've added some html comments on stuff that needs more work

I think "compute services" needs its own topic, then we can keep this page shorter and more descriptive, maybe keep just the introductory part about analysis taking too long on a laptop. But for now it is at least an improvement on the old version and no longer outdated.