### PR TITLE
Fix ResearchData links

### DIFF
--- a/guides/document-and-preserve.qmd
+++ b/guides/document-and-preserve.qmd
@@ -50,7 +50,7 @@ More information on selecting data:
 
 * Tjalsma, H. & Rombouts, J. (2011). [Selection of research data: Guidelines for appraising and selecting research data](https://dans.knaw.nl/nl/over/organisatie-beleid/publicaties/DANSselectionofresearchdata.pdf). Data Archiving and Networked Services (DANS).
 * Digital Curation Centre (DCC): Whyte, A. & Wilson, A. (2010). [How to appraise and select research data for curation](http://www.dcc.ac.uk/resources/how-guides/appraise-select-data). DCC How-to Guides. Edinburgh: Digital Curation Centre.
-* Research Data Netherlands: [Data selection](https://datasupport.researchdata.nl/en/start-the-course/iv-harvest-phase/data-selection).
+* Research Data Netherlands: [Data selection](https://danstraining.moodlecloud.com/mod/page/view.php?id=280).
 
 ### Data Set Packaging: Which Files should be Part of my Dataset?
 
@@ -70,7 +70,7 @@ Depending on the research project it may be that more than one dataset is stored
 
 ### Documenting your data
 
-Data documentation aims to describe the collected data to make it easier to use, retrieve and manage. Data documentation takes various forms and describes the data on multiple levels. The description of the dataset and data object is also referred to as metadata, i.e. data about the data. One way to do add metadata is to attach a readme file to your data. [ResearchData NL](https://datasupport.researchdata.nl/en/start-the-course/iii-research-phase/data-documentation) offers guidance for this. The CESSDA has made very detailed guidance available for creating [documentation and metadata](https://www.cessda.eu/Training/Training-Resources/Library/Data-Management-Expert-Guide/2.-Organise-Document/Documentation-and-metadata) for your data.
+Data documentation aims to describe the collected data to make it easier to use, retrieve and manage. Data documentation takes various forms and describes the data on multiple levels. The description of the dataset and data object is also referred to as metadata, i.e. data about the data. One way to do add metadata is to attach a readme file to your data. [ResearchData NL](https://danstraining.moodlecloud.com/mod/page/view.php?id=275) offers guidance for this. The CESSDA has made very detailed guidance available for creating [documentation and metadata](https://www.cessda.eu/Training/Training-Resources/Library/Data-Management-Expert-Guide/2.-Organise-Document/Documentation-and-metadata) for your data.
 
 ![An image layering five different kinds of metadata, with the FAIR principles on the outside, followed by discipline metadata standards, project documentation, metadata data set, and metadata data object.](https://s3.amazonaws.com/libapps/accounts/62029/images/Metadata.png)
 


### PR DESCRIPTION
The ResearchData trainings moved their trainings elsewhere, and the links are updated to reflect the same content as good as I could find. I assume the previous link structure represented the course structure, which was represented in the new training environment.

Fixes #136.
