### PR TITLE
Remove broken codebook example links

### DIFF
--- a/guides/document-and-preserve.qmd
+++ b/guides/document-and-preserve.qmd
@@ -99,12 +99,7 @@ Like any other kind of "book," some codebooks are better than others. The best c
 * Details about the data: the meaning of the variables, whether they are character or numeric, and if numeric, what format
 * Text of the questions and responses: some even include how many people responded a particular way.
 
-More information about codebooks can be found on the website of the [Kent State University Library](https://libguides.library.kent.edu/SPSS/Codebooks) (specifically useful if you want to create a codebook in SPSS) and on the website of the [Data Documentation Initiative](https://ddialliance.org/training/getting-started-new-content/create-a-codebook) (specifically useful for researchers in the social sciences).
-
-Examples of codebooks are
-
-* [The Guide to Social Science Data Preparation and Archiving. 5th ed. Inter-university Consortium for Political and Social Research (ICPSR) (2012)](http://www.icpsr.umich.edu/files/deposit/dataprep.pdf).
-* [Institute for Health and Care Research (EMGO) codebook (2015)](http://www.emgo.nl/kc/codebook/)
+More information about codebooks can be found on the website of the [Kent State University Library](https://libguides.library.kent.edu/SPSS/Codebooks) (specifically useful if you want to create a codebook in SPSS) and on the website of the [Data Documentation Initiative](https://ddialliance.org/training/getting-started-new-content/create-a-codebook) (specifically useful for researchers in the social sciences). You can also look at [The Guide to Social Science Data Preparation and Archiving. 5th ed. Inter-university Consortium for Political and Social Research (ICPSR) (2012)](http://www.icpsr.umich.edu/files/deposit/dataprep.pdf).
 
 ## Metadata
 


### PR DESCRIPTION
This PR removes the broken codebook example link, and moves an instructional booklet out of the examples.

Fixes #137 (but see also #156 to track the addition of example codebooks in the future).
