### PR TITLE
Fix quarto warnings

### DIFF
--- a/guides/publish-and-share.qmd
+++ b/guides/publish-and-share.qmd
@@ -25,7 +25,7 @@ Data relevant for future research should be archived for the long term. A datase
 
 Researchers should bear in mind that repositories can charge for archiving data. These costs can vary according to the data volume and the archive used. It is important that you consider in advance how you will budget for these costs. Whatever archiving option is used, proper descriptions of the dataset(s) and adding [metadata](http://libguides.vu.nl/rdm/metadata) are important.
 
-### Deposit your data @VU Amsterdam
+### Deposit your data
 
 VU Amsterdam requests that researchers archive the data used in a publication in a repository for at least ten years after the release of the publication (see also [VU Policies & Regulations](http://libguides.vu.nl/rdm/policies-regulations)). There are a lot of digital archives and many more keep appearing.  
   

--- a/topics/fair-principles.qmd
+++ b/topics/fair-principles.qmd
@@ -44,7 +44,7 @@ If you have questions about metadata and documentation, contact the [RDM Support
 
 If you choose a repository that: assigns a persistent identifier to both the data and the metadata; attaches metadata to the data according to standard metadata schemas; releases data with a license; and provides access to the data and metadata via an open and standard communication protocol (such as http) – then your data will meet many, if not most, of the FAIR principles.
 
-The VU provides [three repositories](repositories.qmd) which meets all of these conditions:
+The VU provides three repositories which meets all of these conditions:
 
 - [DataverseNL](https://dataverse.nl/dataverse/vuamsterdam)
 - Yoda - [Yoda information page](https://yoda.vu.nl/site/) and [Yoda publication platform](https://commons.datacite.org/doi.org?query=client.uid:delft.vudata)


### PR DESCRIPTION
This PR fixes some standard Quarto warnings, that needed to be adjusted to ensure everything works smoothly. This is similar to the changes in #148, and are general quality improvements without major consequence for the content.


