### PR TITLE
Remove home from nav

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -19,8 +19,6 @@ website:
     title: false
     collapse-below: lg
     left:
-      - text: "Home"
-        file: index.qmd
       - text: "Blog"
         file: blog.qmd
       - text: "Topics"


### PR DESCRIPTION
This PR removes the home button from the navigation, as UX indicated that the logo already returning home is sufficient.

Relates to #73.
