### PR TITLE
Init categories for guides

### DIFF
--- a/guides.qmd
+++ b/guides.qmd
@@ -3,6 +3,7 @@ title: "Guides"
 listing:
   contents: guides
   type: grid
+  categories: true
 include-in-header:
   text: |
     <style type="text/css">


### PR DESCRIPTION
This PR initializes the use of categories for the guides. Currently, there are no categories so the functionality is limited, but it is pre-empting the issue raised in #116.

Fixes #116 (somewhat)
