### PR TITLE
Add persistent identifier link instead of include

### DIFF
--- a/topics/data-publication.qmd
+++ b/topics/data-publication.qmd
@@ -28,7 +28,7 @@ In addition to archiving research data in a data repository, you may choose to p
 <!-- - [Journal of Open Health Data](http://openhealthdata.metajnl.com/) -->
 - [Journal of Open Psychology Data](https://openpsychologydata.metajnl.com/)
 
-{{< include ../topics/persistent-identifier.qmd >}}
+Archiving your data in a repository or publishing a data article are both ways to get a [Persistent Identifier for your data](./persistent-identifier.qmd).
 
 ## Licensing the data
 


### PR DESCRIPTION
This PR removes the include statement, as topics should not have these (only guides). It adds a relative link instead.

Fixes #175.
