### PR TITLE
Update topics table

### DIFF
--- a/topics.qmd
+++ b/topics.qmd
@@ -3,5 +3,8 @@ title: "Topics"
 listing:
   contents: topics
   type: table
+  table-striped: true
+  table-hover: true
+  fields: [title, reading-time]
 ---
 


### PR DESCRIPTION
This PR updates the topics table to be more informative, by removing the author field. It also adds an alternating row color, to help visual support in row alignment.

It adds the reading time to help estimate length of the topics. It may assist us in identifying what topics are too long at this time.

Fixes #119.
