### PR TITLE
Refine data citation (see #128), add CFF topic

### DIFF
--- a/topics/cff.qmd
+++ b/topics/cff.qmd
@@ -1,0 +1,26 @@
+---
+title: Citation File Format (CFF)
+---
+
+A Citation File Format (CFF) is a computer file that contains all information needed to cite something. For example, a dataset or a piece of software.
+
+Several data and software repositories, such as Zenodo and GitHub, support this format and enable others to easily select the citation information in their preferred format. Most reference managers can work with these standardized citation files, and automatically format the references in a document.
+
+![A screenshot of the interface to cite a GitHub repository](../public/github_citation_file.png "Cite a GitHub repository that contains a citation file")
+
+An example, CFF-file is given below, but to enable you to easily create a CFF-file you can use this [website](https://citation-file-format.github.io/cff-initializer-javascript/#/).
+
+```yaml
+cff-version: 1.2.0
+message: "If you use this data, please cite it as below."
+authors:
+ - family-names: Druskat
+   given-names: Stephan
+   orcid: https://orcid.org/1234-5678-9101-1121
+title: "My Research Software"
+version: 2.0.4
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.1234
+date-released: 2021-08-11
+```

--- a/topics/data-citation.qmd
+++ b/topics/data-citation.qmd
@@ -4,7 +4,9 @@ title: Data Citation
 
 ## Citation Elements
 
-Citing data is not different from citing a publication. Make sure to check the rules of the journal to know how you should cite when writing an article for a specific academic journal. For all of the journals, however, the minimum compulsory elements in a data citation include:
+Citing data is not different from citing a journal publication. Similar to citing a journal publication, it helps to give and receive credit, and show the impact of the original source.
+
+Make sure to check the rules of the journal to know how you should cite when writing an article for a specific academic journal. For all of the journals, however, the minimum compulsory elements in a data citation include:
 
 * Author(s): Name of the author (creator) of the dataset
 * Title: Name of the dataset
@@ -19,9 +21,11 @@ Optional elements that may be included in the reference are:
 * Creation Date
 * Date of Consultation (last)
 
-**Example of a data citation:**
+### Example data citation
 
 Stephens, William, 2020, "Resiliences to Radicalisation - QSort Data", [https://doi.org/10.34894/35MTMN](https://doi.org/10.34894/35MTMN), DataverseNL, V1.
+
+---
 
 For more information, see the following guidelines:
 
@@ -30,25 +34,4 @@ For more information, see the following guidelines:
 * [DCC UK](https://www.dcc.ac.uk/resources/briefing-papers/introduction-curation/data-citation-and-linking)
 * [Data Citation Synthesis Group (2014). Joint Declaration of Data Citation Principles. Martone M. (ed.) San Diego CA: FORCE11](https://www.force11.org/group/joint-declaration-data-citation-principles-final)
 
-### Citation file
-
-A citation file is a computer file that contains all information needed to cite a dataset. Several data and software repositories, such as Zenodo and GitHub, support this format and enables enables others to easily select the citation information in their preferred format. Most reference managers (e.g., Zenodo) can work with these standardized citation files, and automatically format the references in a document.
-
-![A screenshot of the interface to cite a GitHub repository](../public/github_citation_file.png "Cite a GitHub repository that contains a citation file")
-
-An example, CFF-file is given below, but to enable you to easily create a CFF-file you can use this [website](https://citation-file-format.github.io/cff-initializer-javascript/#/).
-
-```yaml
-cff-version: 1.2.0
-message: "If you use this data, please cite it as below."
-authors:
- - family-names: Druskat
-   given-names: Stephan
-   orcid: https://orcid.org/1234-5678-9101-1121
-title: "My Research Software"
-version: 2.0.4
-identifiers:
-  - type: doi
-    value: 10.5281/zenodo.1234
-date-released: 2021-08-11
-```
+Relevant is also the [Citation File Format (CFF)](./cff.qmd).


### PR DESCRIPTION
This PR refines the data citation topic based on the feedback from @vansteph in #128. It also splits the Citation File Format (CFF) into its own topic, as it is relevant beyond the data citation alone.

Fixes #128.
