### PR TITLE
Ignore github contributors links

### DIFF
--- a/.github/workflows/external-link-checker.yml
+++ b/.github/workflows/external-link-checker.yml
@@ -17,7 +17,7 @@ jobs:
       id: lychee
       uses: lycheeverse/lychee-action@v1
       with:
-        args: "--exclude doi.org --exclude data.4tu.nl --exclude isbn.org '**/*.qmd'"
+        args: "'**/*.qmd' --exclude doi.org --exclude data.4tu.nl --exclude isbn.org --exclude github.com/ubvu/open-handbook"
         format: markdown
         jobSummary: true
     - name: Comment PR


### PR DESCRIPTION
The external link checker created unnecessary noise for the github.com contributor links. This commit ignores those so we do not get desensitized about link issues 😊
