### PR TITLE
Add CNAME to build process

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+rdm.vu.nl

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -32,7 +32,7 @@ website:
         text: GitHub VU Open Handbook
       # - icon: rss
       #   href: https://quarto.org/docs/blog/index.xml
-      #   text: Quarto Blog RSS   
+      #   text: Quarto Blog RSS
   page-footer:
     left:
       - text: "CC0 Public Domain Dedication"
@@ -50,10 +50,11 @@ bibliography: references.bib
 
 resources:
   - "public/*"
+  - CNAME
 format:
   html:
     toc: true
-    theme: 
+    theme:
       - cosmo # https://bootswatch.com/
       - custom.scss # https://quarto.org/docs/output-formats/html-themes.html#theme-options
     code-copy: true


### PR DESCRIPTION
This PR adds the CNAME (that is, domain name `rdm.vu.nl`) to the build process. This means it will be on `gh-pages` when a new build is created.

@Jolien-S documented an issue that the website was 404'ing upon merging a pull request, which stressed her out and I am sorry that that happened! I could have foreseen this issue and saved the stress...

Most importantly, this fix will prevent that from happening in the future.
