### PR TITLE
Add link to PURE libguide

### DIFF
--- a/guides/publish-and-share.qmd
+++ b/guides/publish-and-share.qmd
@@ -154,5 +154,5 @@ Just like your publications, data that you have collected for your research cons
 
 1. Log into the [VU](https://research.vu.nl/admin/workspace.xhtml) Research Portal (PURE) using your VU or VUmc credentials
 2. Click on the “+” (plus) icon next to selecting “Datasets” in the overview
-3. You can fill in the form using this [manual (NL)](../public/Registreer_Datasets_in_Pure.pdf)/[manual (EN)](), and read more about the various metadata in use (generic and subject specific)
+3. You can fill in the form using this [manual (NL)](../public/Registreer_Datasets_in_Pure.pdf)/[manual (EN)](https://libguides.vu.nl/pure-managing-publications/start), and read more about the various metadata in use (generic and subject specific)
 4. Click on “Save” to store the registration


### PR DESCRIPTION
This adds a link to the PURE manual in libguide, as we could not get the manual in english.

Fixes #208.
