### PR TITLE
Add hackathon 4 blog

### DIFF
--- a/blog/2024-11-01hackathon.qmd
+++ b/blog/2024-11-01hackathon.qmd
@@ -7,6 +7,8 @@ author:
   - Jolien Scholten
   - Tycho Hofstra
   - Elisa Rodenburg
+  - Stephanie van de Sandt
+
 categories: ["hackathon"]
 ---
 
@@ -18,10 +20,11 @@ We considered how (un)balanced the various [Topics](https://rdm.vu.nl/topics.htm
 
 One breakout group focused on creating templates for both kinds of topics, resulting in an initial structure that will make it easier to start new topics in the future. Specifically we propose the following template structure for tools (for example, Qualtrics, HPC, DMPonline):
 
-* What is it?
+* What is it? 
 * What can it be used for?
 * How to request access
-* Getting started
+* Are there costs involved
+* Getting started (with screenshot)
 * How does it work/more detailed instructions
 * Contact
 

--- a/blog/2024-11-01hackathon.qmd
+++ b/blog/2024-11-01hackathon.qmd
@@ -1,0 +1,55 @@
+---
+title: Fourth Handbook Hackathon
+date: "2024-11-01"
+author:
+  - Chris Hartgerink
+  - Lena Karvovskaya
+  - Jolien Scholten
+  - Tycho Hofstra
+  - Elisa Rodenburg
+categories: ["hackathon"]
+---
+
+On October 30th, 2024, all authors participated in the fourth hackathon for the Research Support Handbook. Since the [third hackathon](https://rdm.vu.nl/blog/2024-09-30hackathon.html), we migrated to `rdm.vu.nl`, which is a huge milestone! 🎉
+
+For the fourth hackathon, we focused on tying up loose ends that we accumulated. The migration means we are now in a stable state, yet there is always more work to be done. During this hackathon, we focused on picking up stale discussions, reviewing open pull requests, and generally closing issues that we took too long to revisit.
+
+We considered how (un)balanced the various [Topics](https://rdm.vu.nl/topics.html) had gotten, because we want readers to be able to form consistent expectations. We observed that some topics are related to tools, others to concepts. Some topics are concise, whereas others are lengthy.
+
+One breakout group focused on creating templates for both kinds of topics, resulting in an initial structure that will make it easier to start new topics in the future. Specifically we propose the following template structure for tools (for example, Qualtrics, HPC, DMPonline):
+
+* What is it?
+* What can it be used for?
+* How to request access
+* Getting started
+* How does it work/more detailed instructions
+* Contact
+
+And the following structure for concepts (for example, DMP, data citation, data storage):
+
+* What is it
+* Examples
+* Tools/services/resources related to concept provided by VU
+* How does this help you in your research?
+
+We will follow up with a new hackathon in late november.
+
+## Issues worked on
+
+<https://github.com/ubvu/open-handbook/issues/232>
+
+<https://github.com/ubvu/open-handbook/issues/233>
+
+## Pull Requests worked on
+
+<https://github.com/ubvu/open-handbook/pull/229>
+
+<https://github.com/ubvu/open-handbook/pull/231>
+
+<https://github.com/ubvu/open-handbook/pull/234>
+
+<https://github.com/ubvu/open-handbook/pull/235>
+
+<https://github.com/ubvu/open-handbook/pull/236>
+
+<https://github.com/ubvu/open-handbook/pull/237>


### PR DESCRIPTION
This PR adds the hackathon blog. It is dated on November 1st, which is when it is aimed to be published.
