### PR TITLE
Update trainings.qmd

### DIFF
--- a/topics/trainings.qmd
+++ b/topics/trainings.qmd
@@ -10,9 +10,9 @@ Do you want to meet other researchers, improve your programming skills, or ask q
 
 ---
 
-- URL: <https://ubvu.github.io/bytes-and-bites/>
+- More information: <https://ubvu.github.io/bytes-and-bites/>
 - Topics: Programming, Python, R, Community, Software, Coding
-- Target audience: everybody
+- Target audience: Students, researchers, data stewards
 - Status: Monthly
 - Duration: 120 minutes
 - Online/in-person: In-person
@@ -29,7 +29,8 @@ Are you analysing tabular data in your research? Would you like to learn how to 
 
 ---
 
-- URL: <https://datacarpentry.org/lessons/#social-science-curriculum>
+- Registration form: <https://vu-nl.libcal.com/calendar/universitylibrary?t=g&q=data%20carpentry&cid=7052&cal=7052&inc=0>
+- Training materials: <https://datacarpentry.org/lessons/#social-science-curriculum>
 - Topics: Software skills, Data analysis, Plotting, R, OpenRefine, Spreadsheets
 - Target audience: Researchers, students
 - Status: Available on set moments
@@ -46,10 +47,10 @@ The Data Horror Escape Room was made for the Data Horror week 2020.
 
 ---
 
-- URL: <https://doi.org/10.5281/zenodo.6949510>
+- Training materials: <https://doi.org/10.5281/zenodo.6949510>
 - Licence: CC-BY-SA-4.0
 - Topics: Research data, Escape room, Workshop, Data management, Research data management, FAIR
-- Target audience: Everybody
+- Target audience: Students, researchers, data stewards
 - Status: Active
 - Duration: 60 minutes
 - Online/in-person: Online
@@ -65,10 +66,10 @@ The Open Science Horror Escape Room was made for the Data Horror week 2021.
 
 ---
 
-- URL: <https://doi.org/10.5281/zenodo.6963493>
+- Training materials: <https://doi.org/10.5281/zenodo.6963493>
 - Licence: CC-BY-4.0
 - Topics: Open science, Escape room, Workshop, Open access, Research data management, FAIR
-- Target audience: Everybody
+- Target audience: Students, researchers, data stewards
 - Status: Active
 - Duration: 30-60 minutes
 - Online/in-person: Online
@@ -84,10 +85,10 @@ The Software Horror Escape Room was made for the Data Horror week 2022.
 
 ---
 
-- URL: <https://doi.org/10.5281/zenodo.7350527>
+- Training materials: <https://doi.org/10.5281/zenodo.7350527>
 - Licence: CC-BY-4.0
 - Topics: Software management, Escape room, Workshop, Software, Research data management, FAIR,
-- Target audience: Everybody
+- Target audience: Students, researchers, data stewards
 - Status: Active
 - Duration: 60 minutes
 - Online/in-person: Online
@@ -102,7 +103,7 @@ The data package offers a powerpoint and general guidelines in hosting the works
 
 ---
 
-- URL: <https://doi.org/10.5281/zenodo.10174000>
+- Training materials: <https://doi.org/10.5281/zenodo.10174000>
 - Licence: CC-BY-4.0
 - Topics: Metadata, Contextual metadata, LEGO, Workshop
 - Target audience: Researchers
@@ -120,9 +121,9 @@ The OSF is an open-source project management tool that supports researchers thro
 
 ---
 
-- URL: <https://osf.io/ab923/>
+- Training materials: <https://osf.io/ab923/>
 - Topics: OSF, Preprint, Publishing, Archiving, RDM tools, Data management
-- Target audience: Everybody
+- Target audience: Students, researchers, data stewards
 - Status: Bi-annually during the Support Training Days
 - Duration: 120 minutes
 - Online/in-person: Online
@@ -135,10 +136,10 @@ This card game is based on "Cards Against Humanity" and teaches basic concepts o
 
 ---
 
-- URL: <https://doi.org/10.5281/zenodo.10017280>
+- Training materials: <https://doi.org/10.5281/zenodo.10017280>
 - Licence: CC-BY-4.0
 - Topics: Open science, Card game, Workshop, Game, Research data management, FAIR, Software management
-- Target audience: Everybody (familiar with academics)
+- Target audience: Students, researchers, data stewards
 - Status: Active
 - Duration: 30-60 minutes
 - Online/in-person: Online and in-person
@@ -155,10 +156,10 @@ In Open loves Science, players are invited to engage in playful and deep convers
 
 ---
 
-- URL: <https://nlesc.github.io/open-loves-science/>
+- Training materials: <https://nlesc.github.io/open-loves-science/>
 - Licence: CC-BY-4.0
 - Topics: Open science, Card game, Workshop, Game, Research data management, FAIR, Software management
-- Target audience: Everybody
+- Target audience: Students, researchers, data stewards
 - Status: Active
 - Duration: 30-60 minutes
 - Online/in-person: Online and in-person
@@ -179,7 +180,8 @@ The lessons are designed for programming beginners and do not require any experi
 
 ---
 
-- URL: <https://software-carpentry.org/lessons/>
+- Registration form: <https://vu-nl.libcal.com/calendar/universitylibrary?t=g&q=software%20carpentry&cid=7052&cal=7052&inc=0>
+- Training materials: <https://software-carpentry.org/lessons/>
 - Topics: Coding, Software skills, Python, R, Bash, Unix Shell, Git, GitHub, Version control
 - Target audience: Researchers, students
 - Status: Available on set moments
@@ -192,13 +194,14 @@ The lessons are designed for programming beginners and do not require any experi
 
 In this course you learn how you write a good Data Management Plan (DMP) for your research project. The course is aimed at PhD students at the beginning of their research project.
 
-The course consists of 2 online workshops and an online peer review session. Please make sure that you are able to participate in all three events.
+The course consists of 2 workshops (either in person or online) and an online peer review session. In preparation for the workshops, you are requested to study some materials. You will do three assignments (RDM Framework, First draft of DMP and Final DMP) and peer review one other participant's DMP. You will receive a certificate worth 1 EC for this course if you successfully complete all mandatory components.
 
 ---
 
-- URL:
-- Topics:
+- Registration form: https://vu-nl.libcal.com/calendar/universitylibrary?t=g&q=writing%20a%20data%20management%20plan&cid=7052&cal=7052&inc=0
+- More information: https://vu.nl/en/employee/university-library/course-for-phd-students-writing-a-data-management-plan
+- Topics: Data Management Plan, data overview, legal and ethical requirements, data storage, data archiving and publishing, metadata and documentation
 - Target audience: Researchers, PhD
 - Status: Available on set moments
 - Duration: 60 minutes
-- Online/in-person: Online -->
+- Online/in-person: In-person or online (see registration form for particular course) -->


### PR DESCRIPTION
I added and changed a few things:
- where 'Target audience' said 'everybody', I replaced this with 'Students, researchers, data stewards'
- I replaced 'URL' with either 'More information', 'Registration form' or 'Training materials'. 
- Where relevant, I added URLs based on the categories listed in the previous bullet point. Some only have one URL, others two (so far we don't have trainings for which all three categories apply, but in principle this should be possible as well.