### PR TITLE
Add automated issues for outdated topics, guides

### DIFF
--- a/.github/workflows/periodic-guide-check.yml
+++ b/.github/workflows/periodic-guide-check.yml
@@ -1,0 +1,36 @@
+name: Open issues for guides that need to be updated
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 1 * *" # Runs on the first day of every month
+
+jobs:
+  check-guides:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Find outdated files (90 days)
+        id: find-outdated
+        run: |
+          outdated_files=$(find guides/ -type f -mtime +90)
+          echo "::set-output name=outdated_files::$outdated_files"
+
+      - name: Create issues for outdated files
+        if: steps.find-outdated.outputs.outdated_files != ''
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const outdatedFiles = `{{ steps.find-outdated.outputs.outdated_files }}`.split('\n').filter(Boolean);
+            for (const file of outdatedFiles) {
+              github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `Update needed for ${file}`,
+                body: `The guide \`${file}\` has not been updated in the last three months. Please review and update it as necessary.`,
+                labels: ['maintenance']
+              });

--- a/.github/workflows/periodic-topic-check.yml
+++ b/.github/workflows/periodic-topic-check.yml
@@ -1,0 +1,36 @@
+name: Open issues for topics that need to be updated
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 1 * *" # Runs on the first day of every month
+
+jobs:
+  check-topics:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Find outdated files (90 days)
+        id: find-outdated
+        run: |
+          outdated_files=$(find topics/ -type f -mtime +90)
+          echo "::set-output name=outdated_files::$outdated_files"
+
+      - name: Create issues for outdated files
+        if: steps.find-outdated.outputs.outdated_files != ''
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const outdatedFiles = `{{ steps.find-outdated.outputs.outdated_files }}`.split('\n').filter(Boolean);
+            for (const file of outdatedFiles) {
+              github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `Update needed for ${file}`,
+                body: `The file \`${file}\` has not been updated in the last three months. Please review and update it as necessary.`,
+                labels: ['maintenance']
+              });


### PR DESCRIPTION
This PR adds an automation to open an issue for all the outdated topics and guides, which have not been modified in the last 90 days. 

The 90 days is arbitrary, and can of course be adjusted to what works best for the editors. I picked 90 as a start, to not overrun the repo with requests to update, while also allowing us to trial run a few rounds of this in the foreseeable duration of the project.

The issues will be opened on the first day of the month, which may or may not be an appropriate schedule. We can discuss whether to put this to the first monday of the month, to ensure it does not open issues on the weekend.

Fixes #212.
