### PR TITLE
Remove double content

### DIFF
--- a/guides/publish-and-share.qmd
+++ b/guides/publish-and-share.qmd
@@ -114,7 +114,6 @@ Instead of archiving research data in a data repository, you may choose to publi
 ../topics/persistent-identifier.qmd
 ```
 
-
 ```{.include shift-heading-level-by=2}
 ../topics/data-and-software-licensing.qmd
 ```
@@ -125,37 +124,6 @@ Instead of archiving research data in a data repository, you may choose to publi
 
 ## Dataset Registration
 
-### Registration & Findability
-
-When you have finished finalizing a dataset and are ready to archive it, there are many options available. Depending on the research and choices made earlier the archive provides the option to fill in descriptive fields for a dataset. The descriptions in the archives often are automatically created using metadata standards like DataCite or Dublin Core, or some other type of standard. See also the item [Metadata](../topics/metadata.qmd) in this LibGuide.
-
-When registering a dataset in an archive it is important to use unique identifiers to allow for increased findability and easy attribution & citation. Examples of this are:
-
-* **Personal names**: try to consistently use the same notation for all researchers and assistants that are included as authors
-* **ORCID**: using a unique identifier like this for all authors is recommended. More information is [available here](https://libguides.vu.nl/orcid).
-* **Institutonal names**: avoid using different versions (or language versions) of participating Institutes/organizations and departments. In the case of the VU the official written name is: Vrije Universiteit Amsterdam. For each organization or Institute that is included: try to make sure that the official name is used each time.
-
-Some archives also allow you to preregister your project/dataset. Examples are:
-
-* [Open Science Framework](https://help.osf.io/hc/en-us/sections/360003624093-Create-Registrations) (OSF) Registration
-* [Zenodo & registration](https://zenodo.org/deposit)
-
-### Register your Dataset in PURE
-
-Just like your publications, data that you have collected for your research constitute research output, too. Therefore you are required to record your datasets in PURE. Your datasets can be of interest to others, which can in turn lead to new collaboration opportunities. Datasets recorded in PURE also appear in reports that are used for research evaluations. Even if access to your dataset is closed, you are required to register your dataset in PURE. It is a record of the research, data collection and analysis that you have carried out.
-
-#### Benefits of recording your dataset in PURE
-
-* It increases the visibility and findability of your datasets
-* It contributes to re-use and transparency
-* It boosts your collaboration opportunities
-* It counts towards research evaluations and assessments
-
-#### How to register your dataset in PURE?
-
-![Screenshot: adding a dataset to your PURE profile](../public/PURE-AddDataset.png)
-
-1. Log into the [VU](https://research.vu.nl/admin/workspace.xhtml) Research Portal (PURE) using your VU or VUmc credentials
-2. Click on the “+” (plus) icon next to selecting “Datasets” in the overview
-3. You can fill in the form using this [manual (NL)](../public/Registreer_Datasets_in_Pure.pdf)/[manual (EN)](https://libguides.vu.nl/pure-managing-publications/start), and read more about the various metadata in use (generic and subject specific)
-4. Click on “Save” to store the registration
+```{.include shift-heading-level-by=1}
+../topics/dataset-and-software-registration.qmd
+```


### PR DESCRIPTION
The content on registering a dataset was duplicated. This uses an include statement to remove the duplication 👍
