### PR TITLE
Elisa title capitalisation

### DIFF
--- a/topics/data-documentation.qmd
+++ b/topics/data-documentation.qmd
@@ -1,5 +1,5 @@
 ---
-title: Data documentation
+title: Data Documentation
 ---
 
 By creating documentation about your research data you can make it easier for yourself or for others to manage, find, assess and use your data. The process of documenting means to describe your data and the methods by which they were collected, processed and analysed. The documentation or descriptions are also referred to as metadata, i.e. data about data. These metadata can take various forms and can describe data on different levels.

--- a/topics/dataset-and-software-registration.qmd
+++ b/topics/dataset-and-software-registration.qmd
@@ -1,5 +1,5 @@
 ---
-title: Dataset and software registration in PURE
+title: Dataset and Software Registration in PURE
 ---
 
 ## Registration & Findability

--- a/topics/persistent-identifier.qmd
+++ b/topics/persistent-identifier.qmd
@@ -1,5 +1,5 @@
 ---
-title: Persistent identifier
+title: Persistent Identifier
 ---
 
 A persistent identifier (PID) is a durable reference to a digital dataset document, website or other object. It is a kind of [ISBN](https://www.isbn.org/about_isbn_standard) for digital files. By using a persistent identifier, you make sure that your dataset will be findable well into the future. A [DOI](https://en.wikipedia.org/wiki/Digital_object_identifier) or [Handle](https://en.wikipedia.org/wiki/Handle_(computing)) are the commonly used PIDs. The [data archiving options](../topics/selecting-data.qmd) at VU Amsterdam commonly offer DOIs.


### PR DESCRIPTION
See the screenshot below. The topic 'Data documentation' is below 'Data Licensing' etc. because documentation isn't capitalised.
To bring this in line and to fix the alphabetical / alphanumerical order I changed title into 'Data Documentation'.
To align with the capitalisation policy I also changed the titles of 'Persistent identifier' and 'Dataset and software registration in PURE'.

![image](https://github.com/user-attachments/assets/08b7c150-13f5-4fff-80d7-41b3a4a682a2)
