### PR TITLE
Elisa updating support

### DIFF
--- a/guides/data-lifecycle.qmd
+++ b/guides/data-lifecycle.qmd
@@ -26,11 +26,11 @@ Here you find references to other organisational units and departments that can 
 
 General Faculty research support and management guidelines are available in the section [Policies & Regulations](./plan-and-design.qmd#vu-general-policies-and-regulations).
 
-### This LibGuide
+### This website
 
 Questions regarding your data or the information on this website?
 
-The [RDS Support](mailto:researchdatamanagement@vu.nl?subject=Libguides%20question) team can help you with all your question on data management plan, data archiving, data store or data privacy & security.
+The [RDM Support](mailto:researchdatamanagement@vu.nl?subject=RDM%20website) team can help you with all your question on data management plan, data archiving, data storing or data privacy & security.
 
 ### VU IT for Research
 
@@ -86,8 +86,8 @@ SURF offers a wide range of services for different phases in the life cycle of y
 
 Do you encounter limitations with your own systems? SURF offers researchers a wide range of services in the field of high performance computing (HPC): thousands of times faster than your PC.
 
-* [Cartesius: National Super Computer](https://www.surf.nl/en/services-and-products/dutch-national-supercomputer/index.html).
-  * It is the most comprehensive system in the field of capability computing in the Netherlands. Cartesius is especially in high demand for its combination of fast processors and internal network, large storage capacity and the ability to process large datasets.
+* [Snellius: National Super Computer](https://www.surf.nl/en/services/snellius-the-national-supercomputer).
+  * It is the most comprehensive system in the field of capability computing in the Netherlands. Snellius is especially in high demand for its combination of fast processors and internal network, large storage capacity and the ability to process large datasets.
 * [Lisa Compute Cluster](https://www.surf.nl/en/lisa-computing-cluster-extra-computing-power-for-research): extra processing power for research.
   * Lisa Compute Cluster combines processing power with user friendliness. Are the limits of your own system inhibiting your research? This service lets you upscale to a higher level. Lisa Compute Cluster is preconfigured with a range of software packages, meaning you can start working right away.
 * [HPC Cloud](https://www.surf.nl/en/services-and-products/hpc-cloud/index.html): your flexible compute infrastructure.

--- a/guides/data-lifecycle.qmd
+++ b/guides/data-lifecycle.qmd
@@ -30,7 +30,7 @@ General Faculty research support and management guidelines are available in the 
 
 Questions regarding your data or the information on this website?
 
-The [RDM Support](mailto:researchdatamanagement@vu.nl?subject=RDM%20website) team can help you with all your question on data management plan, data archiving, data storing or data privacy & security.
+The [RDM Support](mailto:researchdatamanagement@vu.nl?subject=RDM%20website) team can help you with all your questions on data management plans, data storage, data archiving and publishing, and data protection.
 
 ### VU IT for Research
 

--- a/guides/data-lifecycle.qmd
+++ b/guides/data-lifecycle.qmd
@@ -88,15 +88,13 @@ Do you encounter limitations with your own systems? SURF offers researchers a wi
 
 * [Snellius: National Super Computer](https://www.surf.nl/en/services/snellius-the-national-supercomputer).
   * It is the most comprehensive system in the field of capability computing in the Netherlands. Snellius is especially in high demand for its combination of fast processors and internal network, large storage capacity and the ability to process large datasets.
-* [Lisa Compute Cluster](https://www.surf.nl/en/lisa-computing-cluster-extra-computing-power-for-research): extra processing power for research.
-  * Lisa Compute Cluster combines processing power with user friendliness. Are the limits of your own system inhibiting your research? This service lets you upscale to a higher level. Lisa Compute Cluster is preconfigured with a range of software packages, meaning you can start working right away.
-* [HPC Cloud](https://www.surf.nl/en/services-and-products/hpc-cloud/index.html): your flexible compute infrastructure.
-  * HPC Cloud gives you and your project team complete control over your computing infrastructure. The infrastructure ranges from a single work station to a complete cluster and can be expanded to suit your needs. You can use your own operating system and analysis software. HPC Cloud is housed in SURF's own data centre.
+* [SURF Research Cloud](../topics/researchcloud.qmd): your flexible compute infrastructure.
+  * SURF Research Cloud gives you and your project team complete control over your computing infrastructure. The infrastructure ranges from a single work station to a complete cluster and can be expanded to suit your needs. You can use your own operating system and analysis software. HPC Cloud is housed in SURF's own data centre.
 * [Grid](https://www.surf.nl/en/services-and-products/grid/index.html): for processing and storing large datasets.
   * Do you want to process and store large- amounts of data? The Grid may very well be suitable for your project. The grid infrastructure consists of a large number of clusters for computing and data storage, which are interconnected via a fast network.
 * [Visualisation](https://www.surf.nl/en/services-and-products/visualisation/index.html): more insight into your data.
   * Do you want to analyse, process or visualise complex research data or big data? These services give you insight into your research data. SURF's Visualisation service allows you to visualise your own datasets on your desktop. This makes it easy to identify connections between data or gain other insight into your datasets. SURFsara offers a powerful remote visualisation service that combines high performance with ease of use.
-* [Collaboratorium](https://userinfo.surfsara.nl/systems/collaboratorium): a visualization and presentation space for science and industry.
+* [Collaboratorium](https://userinfo.surfsara.nl/systems/collaboratorium): a visualisation and presentation space for science and industry.
 
 ### Expertise, advice and training
 


### PR DESCRIPTION
Quick fixes/updates on the Support page that remove references to services that no longer exist. We should have a better look at this page at some point to decide if its current form still fits our philosophy of the handbook.