### PR TITLE
Fix DDI Alliance Codebook URL (404)

### DIFF
--- a/topics/data-documentation.qmd
+++ b/topics/data-documentation.qmd
@@ -45,4 +45,4 @@ There are several guides for creating a codebook available:
 - [Creating a codebook - Kent State University](https://libguides.library.kent.edu/SPSS/Codebooks)
 - [Creating a codebook - for researchers at VU Amsterdam Faculty for Behavioural and Movement Sciences](https://fgb-rdm.nl/rdm/documentation/Codebooks.html)
 - [Codebook - Amsterdam Public Health](https://aph-qualityhandbook.org/set-up-conduct/methods-data-collection/2-2-quantitative-research/2-2-1-preparation/codebook/)
-- [DDI-Codebook - Data Documentation Initiative Alliance](https://ddialliance.org/Specification/DDI-Codebook/)
+- [DDI-Codebook - Data Documentation Initiative Alliance](https://ddialliance.org/ddi-codebook)


### PR DESCRIPTION
Checked with the original link in the wayback archive that this is similar to the originally linked content:

https://web.archive.org/web/20241105201251/https://ddialliance.org/Specification/DDI-Codebook/


