### PR TITLE
Update URL checker to only check updated files

### DIFF
--- a/.github/workflows/external-link-checker.yml
+++ b/.github/workflows/external-link-checker.yml
@@ -14,14 +14,23 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
-      - name: Run lychee-action on .qmd files
+      - name: Get changed .qmd files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: "**/*.qmd"
+
+      - name: Run lychee-action on changed files
+        if: steps.changed-files.outputs.any_changed == 'true'
         id: lychee
         uses: lycheeverse/lychee-action@v1
         with:
-          args: "'**/*.qmd' --exclude doi.org --exclude data.4tu.nl --exclude isbn.org --exclude github.com/ubvu/open-handbook"
+          args: "${{ steps.changed-files.outputs.all_changed_files }} --exclude doi.org --exclude data.4tu.nl --exclude isbn.org --exclude github.com/ubvu/open-handbook"
           format: markdown
           jobSummary: true
+
       - name: Comment PR
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: thollander/actions-comment-pull-request@v2
         with:
           filePath: ./lychee/out.md


### PR DESCRIPTION
The URL checker was getting very noisy, with the risk of missing actual 404s (#310 as an example).

In this PR, the automation is updated to only check the files that are changed in a PR from here on.

This prevents going off on a sidequest when opening a PR, that has nothing to do with the actually changed content. It also helps keep reviews in focus.

It may be an idea to add a periodic, general check, that posts an issue with 404s across the entire website, but that is something for another time.
