### PR TITLE
Create policies-supporting-vision-open-science

### DIFF
--- a/guides/policies-supporting-vision-open-science
+++ b/guides/policies-supporting-vision-open-science
@@ -3,7 +3,7 @@ title: What policies and regulations support VU's vision on Open Science?
 description: "As open as possible, as closed as necessary."
 ---
 
-Vrije Universiteit Amsterdam is strongly committed to the accessibility of research output, namely publications, data and software. They are important to the visibility, verifiability and reusability of research. To make accessible research output a reality, VU Amsterdam has developed a Research Data and Software Management Policy. This policy is based on a set of VU-internal, national and international policies, principles and regulations. This guide provides references and short explanations of these documents.
+Vrije Universiteit Amsterdam is strongly committed to the accessibility of research output, namely publications, data and software. They are important to the visibility, verifiability and reusability of research. To turn accessible research output into reality, VU Amsterdam has developed a Research Data and Software Management Policy. This policy is based on a set of VU-internal, national and international policies, principles and regulations. This guide provides references and short explanations of these documents.
 
 ## Research Data and Software Management Policy
 
@@ -11,18 +11,22 @@ Vrije Universiteit Amsterdam is strongly committed to the accessibility of resea
 ../topics/research-data-and-software-management-policy.qmd
 ```
 
-## VU Strategie 2020-2025
+## VU Strategy 2020-2025
+
 The Research Data and Software Management Policy follows the [VU Strategy](https://issuu.com/vuuniversity/docs/vu_instellingsplan-eng), in which VU Amsterdam endorses Open Science and FAIR data (see Section 5.1). More information relating to the VU Strategy can be found on the [Strategy page](https://vu.nl/en/about-vu/more-about/strategy).
 
 ## Netherlands Code of Conduct for Research Integrity
-Dutch scientists are required to comply with the [Netherlands Code of Conduct for Research Integrity](https://www.universiteitenvannederland.nl/en/research-integrity). More information about this code of conduct and procedures for violations of academic integrity at VU Amsterdam is available on the page about [Academic Integrity](../topics/academic-integrity.qmd).
+
+Dutch scientists are required to comply with the [Netherlands Code of Conduct for Research Integrity](https://www.universiteitenvannederland.nl/en/research-integrity). More information about this code of conduct and procedures for violations of academic integrity at VU Amsterdam is available on the VU page about [Academic Integrity](../topics/academic-integrity.qmd).
 
 ## FAIR Principles
+
 The aim of the [FAIR Principles](../topics/fair-principles.qmd) is to guide researchers to make their data Findable, Accessible, Interoperable and Reusable.
 
 ## Research assessment criteria
 
 ### Strategy Evaluation Protocol (SEP)
+
 In the Netherlands, research institutes and departments are being evaluated by the [Strategy Evaluation Protocol](https://storage.knaw.nl/2022-06/SEP_2021-2027.pdf) (SEP). One of the aspects that need to be addressed in every evaluation, is Open Science. The extent to which a research institute works openly, is evaluated based on:
 
 * to which extent the research unit opens up its work to other researchers and societal stakeholders;
@@ -32,20 +36,21 @@ In the Netherlands, research institutes and departments are being evaluated by t
 
 ### San Francisco Declaration on Research Assessment (DORA)
 
+The [San Francisco Declaration on Research Assessment](https://sfdora.org/read/) (DORA) contains a list of recommendations to improve the way in which research output is assessed. What is relevant for the VU Research Data and Software Management Policy, is that DORA recommends to evaluate the value and impact of all research output, including research data and research software.
+
 ### Coalition for Advancing Research Assessment (CoARA)
+The [Coalition for Advancing Research Assessment](https://coara.eu/) (CoARA) states that all research output has to be included in research evaluations, including research data and research software. It also recommends to recognise and reward researchers who make their research output available to others at an early stage in their research, and to recognise and reward open collaboration.
 
-## Openness of Research Information
+## Barcelona Declaration on Open Research Information
 
-### Barcelona Declaration on Open Research Information
+The [Barcelona Declaration on Open Research Information](https://barcelona-declaration.org/) aims to transform the way research information is used and produced. The declaration strives to make openness of information about the conduct and communication of research the new norm.
 
 ## Legislation and regulations
 
-### GDPR: General Data Protection Regulation
+Reseach activities must comply with all legislation and regulations where applicable, for example:
 
-### Medical Research Involving Human Subjects Act (WMO)
-
-### Dutch Medical Treatment Contracts Act (WGBO)
-
-### Code of Conduct for Health Research
-
-### Experiments on Animals Act
+* [General Data Protection Regulation](https://gdpr-info.eu/) (GDPR) and [Dutch Implementation Act for the GDPR](https://wetten.overheid.nl/BWBR0040940/2021-07-01) (UAVG): This Regulation lays down rules relating to the protection of natural persons with regard to the processing of personal data. The UAVG contains describes implementation of the GDPR for the Netherlands. On the VU page [Working with personal data](https://vu.nl/en/employee/privacy-and-information-security/working-with-personal-data), you can find more information about how VU Amsterdam protects personal data.
+* [Medical Research Involving Human Subjects Act](https://english.ccmo.nl/investigators/legal-framework-for-medical-scientific-research/your-research-is-it-subject-to-the-wmo-or-not) (WMO): WMO is a legal framework for medical scientific research. Research is subject to the WMO if it (i) concerns medical scientific research and (ii) participants are subject to procedures or are required to follow rules of behaviour. If a study is subject to the WMO, it must undergo a review by an accredited Medical Research Ethics Committee (or the [Central Committee on Research Involving Human Subjects](https://english.ccmo.nl/)). In the case of VU Amsterdam, such reviews need to be carried out by the [METC Amterdam UMC](https://metc.amsterdamumc.org/). See also the page about [Ethical Review](../topics/ethical-review.qmd).
+* [Dutch Medical Treatment Contracts Act](https://wetten.overheid.nl/BWBR0005290/2020-07-01/#Boek7_Titeldeel7_Afdeling5) (in Dutch: Wet geneeskundige behandelingsovereenkomst, WGBO): The WGBO is a legal framework that regulates the relationship between patients and care providers and specifies the rights and duties of patients. You can read more about how the WGBO relates to the WMO on [the website of the CCMO](https://english.ccmo.nl/investigators/legal-framework-for-medical-scientific-research/laws/dutch-medical-treatment-contracts-act) (Central Committee on Research Involving Human Subjects).
+* [Code of Conduct for Health Research](https://www.coreon.org/gedragscode-gezondheidsonderzoek/): Code of Conduct provided by COREON (Committee on Regulation of Health Research), which contains a manual in Dutch for the responsible handling of (personal) data and human tissue in health research.
+* [Experiments on Animals Act](https://business.gov.nl/regulation/animal-testing/): This legislation describes the purposes for which animal tests may be carried out. For more information about animal testing at VU Amsterdam, see the pages on the [Animal Welfare Body of VU Amsterdam-VUmc](https://vu.nl/en/employee/guidelines-and-procedures/animal-welfare-body-of-vu-amsterdam-vumc) and the [Amsterdam Division for Laboratory Animal Sciences](https://vu.nl/en/about-vu/research-institutes/amsterdam-animal-research-center-aarc) (ADLAS).

--- a/guides/policies-supporting-vision-open-science
+++ b/guides/policies-supporting-vision-open-science
@@ -1,0 +1,38 @@
+---
+title: What policies and regulations support VU's vision on Open Science?
+description: "As open as possible, as closed as necessary."
+---
+
+Vrije Universiteit Amsterdam is strongly committed to the accessibility of research output, namely publications, data and software. They are important to the visibility, verifiability and reusability of research. To make accessible research output a reality, VU Amsterdam has developed a Research Data and Software Management Policy. This policy is based on a set of VU-internal, national and international policies, principles and regulations. This guide provides references and short explanations of these documents.
+
+## VU Research Data and Software Management Policy
+
+## VU Strategie 2020-2025
+
+## Netherlands Code of Conduct for Research Integrity
+
+## FAIR Principles
+
+## Research assessment criteria
+
+### Strategy Evaluation Protocol (SEP)
+
+### San Francisco Declaration on Research Assessment (DORA)
+
+### Coalition for Advancing Research Assessment (CoARA)
+
+## Openness of Research Information
+
+### Barcelona Declaration on Open Research Information
+
+## Legislation and regulations
+
+### GDPR: General Data Protection Regulation
+
+### Medical Research Involving Human Subjects Act (WMO)
+
+### Dutch Medical Treatment Contracts Act (WGBO)
+
+### Code of Conduct for Health Research
+
+### Experiments on Animals Act

--- a/guides/policies-supporting-vision-open-science
+++ b/guides/policies-supporting-vision-open-science
@@ -5,17 +5,30 @@ description: "As open as possible, as closed as necessary."
 
 Vrije Universiteit Amsterdam is strongly committed to the accessibility of research output, namely publications, data and software. They are important to the visibility, verifiability and reusability of research. To make accessible research output a reality, VU Amsterdam has developed a Research Data and Software Management Policy. This policy is based on a set of VU-internal, national and international policies, principles and regulations. This guide provides references and short explanations of these documents.
 
-## VU Research Data and Software Management Policy
+## Research Data and Software Management Policy
+
+```{.include shift=heading-level-by=2}
+../topics/research-data-and-software-management-policy.qmd
+```
 
 ## VU Strategie 2020-2025
+The Research Data and Software Management Policy follows the [VU Strategy](https://issuu.com/vuuniversity/docs/vu_instellingsplan-eng), in which VU Amsterdam endorses Open Science and FAIR data (see Section 5.1). More information relating to the VU Strategy can be found on the [Strategy page](https://vu.nl/en/about-vu/more-about/strategy).
 
 ## Netherlands Code of Conduct for Research Integrity
+Dutch scientists are required to comply with the [Netherlands Code of Conduct for Research Integrity](https://www.universiteitenvannederland.nl/en/research-integrity). More information about this code of conduct and procedures for violations of academic integrity at VU Amsterdam is available on the page about [Academic Integrity](../topics/academic-integrity.qmd).
 
 ## FAIR Principles
+The aim of the [FAIR Principles](../topics/fair-principles.qmd) is to guide researchers to make their data Findable, Accessible, Interoperable and Reusable.
 
 ## Research assessment criteria
 
 ### Strategy Evaluation Protocol (SEP)
+In the Netherlands, research institutes and departments are being evaluated by the [Strategy Evaluation Protocol](https://storage.knaw.nl/2022-06/SEP_2021-2027.pdf) (SEP). One of the aspects that need to be addressed in every evaluation, is Open Science. The extent to which a research institute works openly, is evaluated based on:
+
+* to which extent the research unit opens up its work to other researchers and societal stakeholders;
+* whether the research unit reuses data;
+* how it stores the research data according to the FAIR principles;
+* how it makes its research data, methods and materials available.
 
 ### San Francisco Declaration on Research Assessment (DORA)
 


### PR DESCRIPTION
This PR creates a new guide that explains which policies, principles and regulations are the foundation of the VU RDSM policy. The target group we have in mind for this page are policy officers and other staff who are involved in policy development, policy implementation, contribute to/maintain policy documents that relate to the RDSM policy, etc.