### PR TITLE
Update pathways-listing.json

### DIFF
--- a/pathways-listing.json
+++ b/pathways-listing.json
@@ -7,6 +7,7 @@
     "/guides/document-and-preserve.html",
     "/guides/plan-and-design.html",
     "/guides/process-and-analyze.html",
-    "/guides/publish-and-share.html"
+    "/guides/publish-and-share.html",
+    "/guides/policies-supporting-vision-open-science.html"
   ]
 }


### PR DESCRIPTION
This is an attempt to make the new guide 'What policies and regulations support VU's vision on Open Science?' visible in the Handbook.