### PR TITLE
Add research lifecycle to homepage

### DIFF
--- a/_components/Lifecycle.jsx
+++ b/_components/Lifecycle.jsx
@@ -19,8 +19,9 @@ const CheckIcon = () => {
   );
 };
 
+// complete, current, upcoming
 const steps = [
-  { id: "01", name: "Discover & Initiate", href: "./guides.html#category=Discover%20%26%20Initiate", status: "complete" },
+  { id: "01", name: "Discover & Initiate", href: "./guides.html#category=Discover%20%26%20Initiate", status: "upcoming" },
   { id: "02", name: "Plan & Design", href: "./guides.html#category=Plan%20%26%20Design", status: "upcoming" },
   { id: "03", name: "Collect & Store", href: "./guides.html#category=Collect%20%26%20Store", status: "upcoming" },
   { id: "04", name: "Process & Analyse", href: "./guides.html#category=Process%20%26%20Analyse", status: "upcoming" },

--- a/_components/Lifecycle.jsx
+++ b/_components/Lifecycle.jsx
@@ -1,0 +1,125 @@
+// import { CheckIcon } from '@heroicons/react/24/solid'
+
+const CheckIcon = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="1.5"
+      stroke="currentColor"
+      class="tw-size-6 tw-text-white"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="m4.5 12.75 6 6 9-13.5"
+      />
+    </svg>
+  );
+};
+
+const steps = [
+  { id: "01", name: "Discover & Initiate", href: "./guides.html#category=Discover%20&%20Initiate", status: "complete" },
+  { id: "02", name: "Plan & Design", href: "./guides.html#category=Plan%20&%20Design", status: "upcoming" },
+  { id: "03", name: "Collect & Store", href: "./guides.html#category=Collect%20&%20Store", status: "upcoming" },
+  { id: "04", name: "Process & Analyse", href: "./guides.html#category=Process%20&%20Analyse", status: "upcoming" },
+  { id: "05", name: "Document & Preserve", href: "./guides.html#category=Document%20&%20Preserve", status: "upcoming" },
+  { id: "06", name: "Publish & Share", href: "./guides.html#category=Publish%20&%20Share", status: "upcoming" },
+];
+
+// Adapted from
+// https://tailwindui.com/components/application-ui/navigation/progress-bars#component-ebd95eb76948b1f97351bc44b63203aa
+function Lifecycle() {
+  return (
+    <>
+      <div className="tw-mx-auto tw-max-w-7xl tw-px-6 lg:tw-px-8">
+        <div className="tw-mx-auto tw-max-w-2xl sm:tw-text-center">
+          <h2 className="tw-mt-2 tw-text-3xl tw-font-bold tw-tracking-tight tw-text-sky-900 sm:tw-text-4xl">
+            Research Lifecycle
+          </h2>
+          <p className="tw-m-6 tw-text-lg tw-leading-8 tw-text-gray-600">
+            Find the relevant guides for the stage of your research.
+          </p>
+        </div>
+      </div>
+      <ol
+        role="list"
+        className="lg:-tw-ml-32 tw-divide-y tw-divide-gray-300 tw-rounded-md tw-border tw-border-gray-300 lg:tw-flex lg:tw-divide-y-0 tw-list-none"
+      >
+        {steps.map((step, stepIdx) => (
+          <li key={step.name} className="tw-relative md:tw-flex md:tw-flex-1">
+            {step.status === "complete" ? (
+              <a
+                href={step.href}
+                className="tw-group tw-flex tw-w-full tw-items-center"
+              >
+                <span className="tw-flex tw-items-center tw-px-6 tw-py-4 tw-text-sm tw-font-medium">
+                  <span className="tw-flex tw-size-10 tw-min-w-10 tw-items-center tw-justify-center tw-rounded-full tw-bg-sky-600 group-hover:tw-bg-sky-800">
+                    <CheckIcon
+                      aria-hidden="true"
+                      className="tw-size-6 tw-text-white"
+                    />
+                  </span>
+                  <span className="tw-ml-4 tw-text-sm tw-font-medium tw-text-gray-900">
+                    {step.name}
+                  </span>
+                </span>
+              </a>
+            ) : step.status === "current" ? (
+              <a
+                href={step.href}
+                aria-current="step"
+                className="tw-flex tw-items-center tw-px-6 tw-py-4 tw-text-sm tw-font-medium"
+              >
+                {/* <span className="tw-flex tw-size-10 tw-w-0 tw-items-center tw-justify-center tw-rounded-full tw-border-2 tw-border-sky-600">
+                  <span className="tw-text-sky-600">{step.id}</span>
+                </span> */}
+                <span className="tw-ml-4 tw-text-sm tw-font-medium tw-text-sky-600">
+                  {step.name}
+                </span>
+              </a>
+            ) : (
+              <a href={step.href} className="tw-group tw-flex tw-items-center">
+                <span className="tw-flex tw-items-center tw-px-6 tw-py-4 tw-text-sm tw-font-medium">
+                  <span className="tw-flex tw-size-10 tw-0 tw-items-center tw-justify-center tw-rounded-full tw-border-2 tw-border-gray-300 group-hover:tw-border-gray-400">
+                    <span className="tw-text-gray-500 group-hover:tw-text-gray-900">
+                      {step.id}
+                    </span>
+                  </span>
+                  <span className="tw-ml-4 tw-text-sm tw-font-medium tw-text-gray-500 group-hover:tw-text-gray-900">
+                    {step.name}
+                  </span>
+                </span>
+              </a>
+            )}
+
+            {stepIdx !== steps.length - 1 ? (
+              <>
+                {/* Arrow separator for lg screens and up */}
+                <div
+                  aria-hidden="true"
+                  className="tw-absolute tw-top-0 tw-right-0 tw-hidden tw-h-full tw-w-5 lg:tw-block"
+                >
+                  <svg
+                    fill="none"
+                    viewBox="0 0 22 80"
+                    preserveAspectRatio="none"
+                    className="tw-size-full tw-text-gray-300"
+                  >
+                    <path
+                      d="M0 -2L20 40L0 82"
+                      stroke="currentcolor"
+                      vectorEffect="non-scaling-stroke"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </div>
+              </>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </>
+  );
+}

--- a/_components/Lifecycle.jsx
+++ b/_components/Lifecycle.jsx
@@ -37,7 +37,7 @@ function Lifecycle() {
       <div className="tw-mx-auto tw-max-w-7xl tw-px-6 lg:tw-px-8">
         <div className="tw-mx-auto tw-max-w-2xl sm:tw-text-center">
           <h2 className="tw-mt-2 tw-text-3xl tw-font-bold tw-tracking-tight tw-text-sky-900 sm:tw-text-4xl">
-            Research Lifecycle
+            Research Life Cycle
           </h2>
           <p className="tw-m-6 tw-text-lg tw-leading-8 tw-text-gray-600">
             Find the relevant guides for the stage of your research.

--- a/_components/Lifecycle.jsx
+++ b/_components/Lifecycle.jsx
@@ -20,12 +20,12 @@ const CheckIcon = () => {
 };
 
 const steps = [
-  { id: "01", name: "Discover & Initiate", href: "./guides.html#category=Discover%20&%20Initiate", status: "complete" },
-  { id: "02", name: "Plan & Design", href: "./guides.html#category=Plan%20&%20Design", status: "upcoming" },
-  { id: "03", name: "Collect & Store", href: "./guides.html#category=Collect%20&%20Store", status: "upcoming" },
-  { id: "04", name: "Process & Analyse", href: "./guides.html#category=Process%20&%20Analyse", status: "upcoming" },
-  { id: "05", name: "Document & Preserve", href: "./guides.html#category=Document%20&%20Preserve", status: "upcoming" },
-  { id: "06", name: "Publish & Share", href: "./guides.html#category=Publish%20&%20Share", status: "upcoming" },
+  { id: "01", name: "Discover & Initiate", href: "./guides.html#category=Discover%20%26%20Initiate", status: "complete" },
+  { id: "02", name: "Plan & Design", href: "./guides.html#category=Plan%20%26%20Design", status: "upcoming" },
+  { id: "03", name: "Collect & Store", href: "./guides.html#category=Collect%20%26%20Store", status: "upcoming" },
+  { id: "04", name: "Process & Analyse", href: "./guides.html#category=Process%20%26%20Analyse", status: "upcoming" },
+  { id: "05", name: "Document & Preserve", href: "./guides.html#category=Document%20%26%20Preserve", status: "upcoming" },
+  { id: "06", name: "Publish & Share", href: "./guides.html#category=Publish%20%26%20Share", status: "upcoming" },
 ];
 
 // Adapted from

--- a/guides/collect-and-store.qmd
+++ b/guides/collect-and-store.qmd
@@ -2,6 +2,7 @@
 title: How can you ensure data protection and security during collection, storage, and transfer?
 image: '/public/cover-images/DALLE_research-data-storage-2.jpg'
 description: "Learn about how to secure research data at any stage."
+categories: ["Collect & Store"]
 ---
 
 ```{.include shift-heading-level-by=1}

--- a/guides/discover-and-initiate.qmd
+++ b/guides/discover-and-initiate.qmd
@@ -2,6 +2,7 @@
 title: How can you discover and reuse existing research data?
 image: '/public/cover-images/DALLE_LEGO-scientist-discovering-metadata.jpg'
 description: "There is so much data out there, that we want to help you find your way more easily."
+categories: ["Discover & Initiate"]
 ---
 
 <!-- markdownlint-disable-next-line MD033 -->

--- a/guides/document-and-preserve.qmd
+++ b/guides/document-and-preserve.qmd
@@ -2,6 +2,7 @@
 title: How can you ensure research data is FAIR?
 image: '/public/cover-images/DALLE_LEGO-egyptologist-evaluating-folder-structure.jpg'
 description: "Making your data Findable, Accessible, Interopable, Reusable is more doable than you might think."
+categories: ["Document & Preserve"]
 ---
 
 ```{.include shift-heading-level-by=1}

--- a/guides/plan-and-design.qmd
+++ b/guides/plan-and-design.qmd
@@ -2,6 +2,7 @@
 title: How can you set up research data management from the start?
 image: '/public/cover-images/DALLE_LEGO-scientists-discussing-metadata.jpg'
 description: "A good plan is half the work."
+categories: ["Plan & Design"]
 ---
 
 ## Research Proposal

--- a/guides/process-and-analyze.qmd
+++ b/guides/process-and-analyze.qmd
@@ -2,6 +2,7 @@
 title: How can you ensure data provenance and accurate data analysis?
 image: '/public/cover-images/DALLE_LEGO-figures-swimming-in-sea-of-notes.jpg'
 description: "Where data and results come from matters."
+categories: ["Process & Analyse"]
 ---
 
 ## Data Provenance

--- a/guides/publish-and-share.qmd
+++ b/guides/publish-and-share.qmd
@@ -2,6 +2,7 @@
 title: What data assets should you publish and what data assets should you archive?
 image: '/public/cover-images/DALLE_sharing-research-data.jpg'
 description: "Archival must happen, publishing can happen."
+categories: ["Publish & Share"]
 ---
 
 ## Selecting an Archive

--- a/index.qmd
+++ b/index.qmd
@@ -15,6 +15,8 @@ include-in-header:
 
 {{< react Hero >}}
 
+{{< react Lifecycle >}}
+
 {{< react Features >}}
 
 {{< react Cta >}}

--- a/topics/data-management-plan.qmd
+++ b/topics/data-management-plan.qmd
@@ -4,7 +4,7 @@ title: Data Management Plan (DMP)
 
 ## What is a DMP
 
-A Data Management Plan (DMP) is a document outlining how research data will be handled throughout the research lifecycle. A DMP is a structured way to address data collection, organization, storage, sharing, and preservation. It also outlines the measures taken to ensure data security and addresses how data will be preserved and made available for future use.
+A Data Management Plan (DMP) is a document outlining how research data will be handled throughout the research life cycle. A DMP is a structured way to address data collection, organization, storage, sharing, and preservation. It also outlines the measures taken to ensure data security and addresses how data will be preserved and made available for future use.
 
 ## DMPonline
 

--- a/topics/trainings.qmd
+++ b/topics/trainings.qmd
@@ -117,7 +117,7 @@ The data package offers a powerpoint and general guidelines in hosting the works
 
 This is a hands-on course to get started with the Open Science Framework (OSF). You won't need any experience with the tool beforehand. We will show the differences and similarities between OSF and other tools at VU Amsterdam (such as Yoda). We will make a preregistration of a (mock) OSF research.
 
-The OSF is an open-source project management tool that supports researchers throughout their entire project lifecycle. As a collaboration tool, OSF helps research teams work on projects privately or make the whole project publicly accessible for broad dissemination. As a workflow system, OSF enables connections to the many scientific tools researchers already use, streamlining their process and increasing efficiency. You may even use OSF as a portfolio tool for sharing your work as a prepublication with potential collaborators.
+The OSF is an open-source project management tool that supports researchers throughout their entire project life cycle. As a collaboration tool, OSF helps research teams work on projects privately or make the whole project publicly accessible for broad dissemination. As a workflow system, OSF enables connections to the many scientific tools researchers already use, streamlining their process and increasing efficiency. You may even use OSF as a portfolio tool for sharing your work as a prepublication with potential collaborators.
 
 ---
 


### PR DESCRIPTION
This PR adds the research lifecycle to the homepage, and allows people to click into the respective guide categories. This is to help navigation, as requested by @Jolien-S.

Please note the category links are not yet working completely, which I am debugging 👍