### PR TITLE
Update trainings.qmd

### DIFF
--- a/topics/trainings.qmd
+++ b/topics/trainings.qmd
@@ -188,7 +188,7 @@ The lessons are designed for programming beginners and do not require any experi
 - Duration: 28 hours over four days
 - Online/in-person: In-person and online (self-study)
 
-<!-- ---
+---
 
 ## Writing a Data Management Plan
 
@@ -204,4 +204,4 @@ The course consists of 2 workshops (either in person or online) and an online pe
 - Target audience: Researchers, PhD
 - Status: Available on set moments
 - Duration: 60 minutes
-- Online/in-person: In-person or online (see registration form for particular course) -->
+- Online/in-person: In-person or online (see registration form for particular course)


### PR DESCRIPTION
This PR makes content about the course Writing a DMP visible. It was commented out initially, because we didn't provide a link. For each training, we now define several types of links, which resulted in links for this course as well. So now the content can be made visible.