### PR TITLE
Changed BAZIS to ADA and analyze to analyse

### DIFF
--- a/guides/data-lifecycle.qmd
+++ b/guides/data-lifecycle.qmd
@@ -16,7 +16,7 @@ Research Data Management is supported by various departments at VU Amsterdam. Th
 
 Here you find references to other organisational units and departments that can help you with matters related to collecting and managing data.
 
-**VU research data support (for all researchers)***
+**VU research data support (for all researchers)**
 
 * [Grant office](https://vu.nl/en/about-vu/more-about/vu-grants-office)
 * [Library](https://vu.nl/en/employee/research-data-support/rdm-support-desk)

--- a/guides/data-lifecycle.qmd
+++ b/guides/data-lifecycle.qmd
@@ -19,7 +19,7 @@ Here you find references to other organisational units and departments that can 
 **VU research data support (for all researchers)***
 
 * [Grant office](https://vu.nl/en/about-vu/more-about/vu-grants-office)
-* [Library](https://vu.nl/en/about-vu/more-about/rdm-support-desk)
+* [Library](https://vu.nl/en/employee/research-data-support/rdm-support-desk)
 * [Legal](https://vu.nl/en/employee/board-and-strategy/institutional-and-legal-affairs)
 * 🔒 [IT for Research](https://services.vu.nl/esc?id=emp_taxonomy_topic&topic_id=4cb138ee97fa0950e553359fe153afff)
 * [IXA](https://www.ixa.nl/)

--- a/guides/data-lifecycle.qmd
+++ b/guides/data-lifecycle.qmd
@@ -38,7 +38,7 @@ The [RDM Support](mailto:researchdatamanagement@vu.nl?subject=RDM%20website) te
 
 VU Amsterdam has an IT team specifically devoted to research: ITvO (from 'IT voor Onderzoek' in Dutch). They provide the following services:
 
-* 🔒 [Bazis HPC cluster computing](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0012830): access to your own linux computational cluster at VU Amsterdam
+* 🔒 [ADA HPC cluster computing](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0012830): access to your own linux computational cluster at VU Amsterdam
 * 🔒 [SciCloud](https://services.vu.nl/esc?id=emp_taxonomy_topic&topic_id=d80aee1f97cf09d0e553359fe153afd7): a service with which you lease virtual server capacity for research purposes
 * 🔒 [SciStor](https://services.vu.nl/esc?id=emp_taxonomy_topic&topic_id=86ad5a5f978f09d0e553359fe153afb3): inexpensively store large sets with research data
 * Advice/consultancy: ITvO will help you to find a suitable technical solution or support for your research group or project

--- a/guides/process-and-analyse.qmd
+++ b/guides/process-and-analyse.qmd
@@ -122,13 +122,13 @@ It’s a service comprising a wide range of resources, compilers and, such as R 
 
 You can find more information on the [SURF Snellius Wiki](https://servicedesk.surf.nl/wiki/display/WIKI/Snellius).
 
-#### BAZIS Compute Cluster
+#### ADA Compute Cluster
 
-IT for Research (ITvO) offers access to your own Linux computational cluster at VU Amsterdam. BAZIS is a managed service for high performance computing (HPC). Research groups can add their own compute server hardware to [BAZIS](../topics/bazis.qmd), ITvO will take care of configuring and maintaining the software stack on your servers.
+IT for Research (ITvO) offers access to your own Linux computational cluster at VU Amsterdam. ADA is a managed service for high performance computing (HPC). Research groups can add their own compute server hardware to [ADA](../topics/ada.qmd), ITvO will take care of configuring and maintaining the software stack on your servers.
 
-BAZIS also has several "community" nodes for use by all VU researchers, sponsored by VU Amsterdam HPC Council.
+ADA also has several "community" nodes for use by all VU researchers, sponsored by VU Amsterdam HPC Council.
 
-BAZIS is connected to SciStor <!--# needs internal link --> providing easy access to your research data and analysis result.
+ADA is connected to SciStor <!--# needs internal link --> providing easy access to your research data and analysis result.
 
 #### VU JupyterHub for education
 

--- a/guides/process-and-analyse.qmd
+++ b/guides/process-and-analyse.qmd
@@ -42,7 +42,7 @@ Extra background information:
   * [Tutorial](https://programminghistorian.org/en/lessons/cleaning-data-with-openrefine) by the Programming Historian
   * Introduction to [Digital Humanities](https://miriamposner.com/classes/dh101f17/tutorials-guides/data-manipulation/get-started-with-openrefine/) with Open Refine
 
-For every step of your data cleaning, good [documentation](../topics/data-documentation.qmd) and clarifying the [data provenance](./process-and-analyze.qmd#data-provenance) is necessary.
+For every step of your data cleaning, good [documentation](../topics/data-documentation.qmd) and clarifying the [data provenance](./process-and-analyse.qmd#data-provenance) is necessary.
 
 ### Data transcription
 
@@ -66,7 +66,7 @@ VU Amsterdam is preparing a decision guide on anonymisation and pseudonymisation
 
 Although data analysis is an ongoing process throughout the research project, this page focuses on the analysis of the data subsequent to its collection. To ensure that research is empirical and verifiable, it is crucial that researchers keep records ([data documentation](../topics/data-documentation.qmd)) of every step made during the data analysis.
 
-Data analysis converts raw/processed data into information that is useful for understanding. Many steps may be required to gain useful information from raw data. The process of [processing](./process-and-analyze.qmd#data-processing) and analysing data may require computing power not readily available or specific storage and protection options. If multiple parties are involved in the analysis, data sharing may also be necessary.
+Data analysis converts raw/processed data into information that is useful for understanding. Many steps may be required to gain useful information from raw data. The process of [processing](./process-and-analyse.qmd#data-processing) and analysing data may require computing power not readily available or specific storage and protection options. If multiple parties are involved in the analysis, data sharing may also be necessary.
 
 Data analysis often requires the use of specialised software.The software offered and licensed by the university currently includes: Stata, SPSS, and Atlas.TI. For open software, see below.
 
@@ -112,7 +112,7 @@ Several options are detailed below. 🔒 [Contact IT for Research](https://servi
 
 ![A set of servers in an undescript room](../public/noaa-ibmsupercomputer.gif)
 
-Roughly speaking, you should try to get access to the HPC when you need to stick a post-it on your laptop or PC that says: "do not touch, analysis ongoing". Or when you want to run analyses parallel to each other, because they take too long. It is important to consider such a situation at the very beginning of your research or when writing your Data Management Plan: is it conceivable that your dataset will become so large or your analysis so complicated that you will need HPC? Please note that this can occur for any discipline and any sort of data, qualitative and quantitative. If you may need HPC, you also need to reconsider your analysis methods. Programmes like SPSS and Excel do not run well on a HPC, and you would need to (learn to) write scripts in [R or Python](../guides/process-and-analyze.qmd#data-analysis). If you want to know if using HPC may be necessary or useful for your project, you can contact [IT for Research](https://services.vu.nl/esc?id=sc_cat_item&sys_id=4e079166978d5950e553359fe153afc5) to ask for more information (select the "Onderzoek service domain").
+Roughly speaking, you should try to get access to the HPC when you need to stick a post-it on your laptop or PC that says: "do not touch, analysis ongoing". Or when you want to run analyses parallel to each other, because they take too long. It is important to consider such a situation at the very beginning of your research or when writing your Data Management Plan: is it conceivable that your dataset will become so large or your analysis so complicated that you will need HPC? Please note that this can occur for any discipline and any sort of data, qualitative and quantitative. If you may need HPC, you also need to reconsider your analysis methods. Programmes like SPSS and Excel do not run well on a HPC, and you would need to (learn to) write scripts in [R or Python](../guides/process-and-analyse.qmd#data-analysis). If you want to know if using HPC may be necessary or useful for your project, you can contact [IT for Research](https://services.vu.nl/esc?id=sc_cat_item&sys_id=4e079166978d5950e553359fe153afc5) to ask for more information (select the "Onderzoek service domain").
 
 #### SURF Snellius Compute Cluster
 

--- a/topics/data-collection.qmd
+++ b/topics/data-collection.qmd
@@ -51,5 +51,4 @@ Some sources for protocols:
 
 * [HANDS](https://data4lifesciences.nl/hands2/data-stewardship/) Handbook for Adequate Natural Data Stewardship by the Federation of Dutch University Medical Centers (UMCs)
 * [Protocols.io](https://www.protocols.io/) - an open access repository of protocols
-* [Protocols Online](https://www.protocol-online.org/) - website with protocols available on the internet, sorted by discipline.
 * [Springer Protocols](https://experiments.springernature.com/) - free and subscribed protocols collected by Springer.

--- a/topics/data-collection.qmd
+++ b/topics/data-collection.qmd
@@ -8,7 +8,7 @@ For data to be considered valid and reliable, data collection should occur consi
 
 * Standardisation: [codebooks](../topics/data-documentation.qmd#codebooks) & [protocols](#data-collection-protocols)
 * Structure / organisation of the data
-* [Data quality assurance methods](../guides/process-and-analyze.qmd#data-processing)
+* [Data quality assurance methods](../guides/process-and-analyse.qmd#data-processing)
 * [Documentation](../topics/data-documentation.qmd) & [metadata](../topics/metadata.qmd)
 * [Storage](../topics/data-storage.qmd) & [protection](../topics/data-protection.qmd)
 

--- a/topics/scistor.qmd
+++ b/topics/scistor.qmd
@@ -6,7 +6,7 @@ categories: [Tools]
 ## What is it?
 The storage service SciStor is intended for cheaply storing large amounts of research data.
 
-SciStor is hosted by IT for Research (ITvO) on the VU campus enabling a high-speed connection to lab equipment, laptops and workstations, the [BAZIS HPC cluster](./bazis.qmd) and [SciCloud](./scicloud.qmd). It can also be accessed off-campus. 
+SciStor is hosted by IT for Research (ITvO) on the VU campus enabling a high-speed connection to lab equipment, laptops and workstations, the [ADA HPC cluster](./ada.qmd) and [SciCloud](./scicloud.qmd). It can also be accessed off-campus. 
 
 Your data is stored in a **share**, basically a folder with group-based access rights (read/write or read-only). Access rights can be set one level deep, so one share could be used to host data from different projects.
 
@@ -25,8 +25,8 @@ In many cases lab equipment can write data directly to SciStor. [IT for Research
 ### Storage space for SciCloud servers
 [SciCloud](./scicloud.qmd) virtual servers are provisioned with a 20 to 50GB local disk. A SciStor share can be directly mounted on the server to increase storage for your application or directly access your source data for analysis.
 
-### BAZIS
-The [BAZIS HPC cluster](./bazis.qmd) is connected to SciStor via a high speed netwodrk. You can run your analysis software directly on your data and easily access the results on your laptop.
+### ADA
+The [ADA HPC cluster](./ada.qmd) is connected to SciStor via a high speed netwodrk. You can run your analysis software directly on your data and easily access the results on your laptop.
 
 ### Sharing data
 Because SciStor is mainly intended for high performance, on-campus use, access is only possible with a VUnetId. If you need to share data with non-VU researchers you could [register them as an external employee](https://vu.nl/en/employee/start-employment-contract/onboarding-external-employees) or host a copy of the data on another storage platform like Research Drive or [Yoda](./yoda.qmd)

--- a/topics/selecting-data.qmd
+++ b/topics/selecting-data.qmd
@@ -52,11 +52,11 @@ More information on selecting data:
 
 A dataset consists of the following documents:
 
-* Raw or cleaned data (if the cleaned data has been archived, the [provenance](../guides/process-and-analyze.qmd#data-provenance) documentation is also required)
+* Raw or cleaned data (if the cleaned data has been archived, the [provenance](../guides/process-and-analyse.qmd#data-provenance) documentation is also required)
 * [Project documentation](../topics/data-documentation.qmd)
 * [Codebook](../topics/data-documentation.qmd#codebooks) or [protocol](../topics/data-collection.qmd#data-collection-protocols)
-* [Logbook or lab journal](../guides/process-and-analyze.qmd#data-provenance) (when available, dependent on the discipline)
-* [Software](../guides/process-and-analyze.qmd#data-processing) (& version) needed to open the files when no preferred formats for the data can be provided
+* [Logbook or lab journal](../guides/process-and-analyse.qmd#data-provenance) (when available, dependent on the discipline)
+* [Software](../guides/process-and-analyse.qmd#data-processing) (& version) needed to open the files when no preferred formats for the data can be provided
 
 See the topic [Metadata](../topics/metadata.qmd) for more information about documenting your data.
 

--- a/topics/snellius.qmd
+++ b/topics/snellius.qmd
@@ -45,7 +45,7 @@ The [SURF User Knowledge Base](https://servicedesk.surf.nl/wiki/display/WIKI/Sne
 
 SURF organises regular "Introduction to Supercomputing" training sessions, these are free to attend for VU researchers. Please consult the [SURF Agenda](https://www.surf.nl/en/agenda) for dates and registration.
 
-Note that there is a free community partition available on the [VU HPC cluser BAZIS](./bazis.qmd), where you can refine your analysis scripts before running them on the more expensive Snellius cluster. Experts at [IT for Research](mailto:itvo.it@vu.nl) can help you optimise your code to run more efficiently. 
+Note that there is a free community partition available on the [VU HPC cluser ADA](./ada.qmd), where you can refine your analysis scripts before running them on the more expensive Snellius cluster. Experts at [IT for Research](mailto:itvo.it@vu.nl) can help you optimise your code to run more efficiently. 
 
 ## Contact
 SURF offers limited direct support for researchers using Snellius. To ask a question create a ticket on the 🔒[SURF Service Desk Portal](https://servicedesk.surf.nl/).


### PR DESCRIPTION
Connected to #373, changing references to BAZIS to ADA on other pages in the handbook 

Also, I noticed that the page process and analyse was still called process and analyze, so I updated that and also updated all references to that page.