### PR TITLE
Add scheduled merging of Pull Requests

### DIFF
--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -1,0 +1,31 @@
+name: Merge Schedule
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+  schedule:
+    - cron: '0 8 * * *'
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge_schedule:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gr2m/merge-schedule-action@v2
+        with:
+          # Merge method to use. Possible values are merge, squash or
+          # rebase. Default is merge.
+          merge_method: squash
+          # Require all pull request statuses to be successful before
+          # merging. Default is `false`.
+          require_statuses_success: 'true'
+          # Label to apply to the pull request if the merge fails. Default is
+          # `automerge-fail`.
+          automerge_fail_label: 'merge-schedule-failed'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds an automation that helps with scheduling Pull Request merges. This can be helpful in case changes are time dependent. This was the case for example in #373.

For reference, the scheduling would work by editing the original post in a pull request (all the way at the top). All needs to be added is:

```
/schedule YYYY-MM-DD
```

And then it will be automatically merged IF all the conditions are met (checks pass, sufficient appoval).

@Jolien-S does this sound feasible/helpful? I don't want to add unnecessary complexity, but this seems like a relevant addition for specific scenarios. It may also help the sustainability in the long run.