### PR TITLE
replace link to non-existent ADA guide

### DIFF
--- a/topics/ada.qmd
+++ b/topics/ada.qmd
@@ -43,7 +43,7 @@ If your research projects require heavy usage of HPC you can consider spending p
 
 ## Getting started
 
-There is a [guide with ADA tips & tricks](../guides/ADA-tips-and-tricks.qmd) in the Handbook.
+You can find information on how to use ADA on [ada-hpc.readthedocs.io](https://ada-hpc.readthedocs.io).
 
 Also take a look at the [SURF wiki Snellius pages](https://servicedesk.surf.nl/wiki/display/WIKI/Snellius), they contain a lot of information that applies to ADA as well.
 


### PR DESCRIPTION
fixes #415 

The link to the guide is premature. I've replaced it with the link to the current readthedocs site. Note that we are planning to move the information there to the handbook, see also #416.