### PR TITLE
Add calendar to `/`

### DIFF
--- a/_components/Cta.jsx
+++ b/_components/Cta.jsx
@@ -1,32 +1,34 @@
 function Cta() {
   return (
     <>
-      <div className="tw-bg-sky-700 tw-rounded-xl">
-      <div className="tw-px-6 tw-py-24 sm:tw-px-6 sm:tw-py-32 lg:tw-px-8">
-        <div className="tw-mx-auto tw-max-w-2xl tw-text-center">
-          <h2 className="tw-text-3xl tw-font-bold tw-tracking-tight tw-text-white sm:tw-text-4xl">
-            Learn practices.
-            <br />
-            Share practices.
-          </h2>
-          <p className="tw-mx-auto tw-mt-6 tw-max-w-xl tw-text-lg tw-leading-8 tw-text-sky-200">
-            Contribute by exploring. The rest will follow. 
-          </p>
-          <div className="tw-mt-10 tw-flex tw-items-center tw-justify-center tw-gap-x-6">
-            <a
-              href="./topics.html"
-              className="tw-rounded-md tw-bg-white tw-px-3.5 tw-py-2.5 tw-text-sm tw-font-semibold tw-text-sky-600 tw-shadow-sm hover:tw-bg-sky-50 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-white"
-            >
-              View topics
-            </a>
-            <a href="./guides.html" className="tw-text-sm tw-font-semibold tw-leading-6 tw-text-white">
-              View guides
-            </a>
+      <div className="tw-bg-sky-700 tw-rounded-xl tw-mb-8">
+        <div className="tw-px-6 tw-py-24 sm:tw-px-6 sm:tw-py-32 lg:tw-px-8">
+          <div className="tw-mx-auto tw-max-w-2xl tw-text-center">
+            <h2 className="tw-text-3xl tw-font-bold tw-tracking-tight tw-text-white sm:tw-text-4xl">
+              Learn practices.
+              <br />
+              Share practices.
+            </h2>
+            <p className="tw-mx-auto tw-mt-6 tw-max-w-xl tw-text-lg tw-leading-8 tw-text-sky-200">
+              Contribute by exploring. The rest will follow.
+            </p>
+            <div className="tw-mt-10 tw-flex tw-items-center tw-justify-center tw-gap-x-6">
+              <a
+                href="./topics.html"
+                className="tw-rounded-md tw-bg-white tw-px-3.5 tw-py-2.5 tw-text-sm tw-font-semibold tw-text-sky-600 tw-shadow-sm hover:tw-bg-sky-50 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-white"
+              >
+                View topics
+              </a>
+              <a
+                href="./guides.html"
+                className="tw-text-sm tw-font-semibold tw-leading-6 tw-text-white"
+              >
+                View guides
+              </a>
+            </div>
           </div>
         </div>
       </div>
-    </div>
     </>
-
   );
 }

--- a/index.qmd
+++ b/index.qmd
@@ -20,3 +20,7 @@ include-in-header:
 {{< react Features >}}
 
 {{< react Cta >}}
+
+## Upcoming events
+
+<iframe src="https://api3-eu.libcal.com/embed_mini_calendar.php?mode=month&amp;iid=4019&amp;cal_id=7052&amp;l=5&amp;tar=0&amp;h=350&amp;audience=&amp;c=&amp;z=32116" style="border-width:0;margin: 0px auto 0px auto; width: 100%" width="270" height="225" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
This PR adds the calendar from the LibGuide to the homepage of the Research Support Handbook.

There seems to be some issue with the data, but this also exists on the original LibGuide - the data source may have become disconnected? 

https://libguides.vu.nl/rdm

If merged, fixes #403.
