### PR TITLE
Add scheduling instructions

### DIFF
--- a/editors-guide.qmd
+++ b/editors-guide.qmd
@@ -22,6 +22,12 @@ Each editor commits themselves to providing timely reviews of topics, guides, or
 
 [^1]: Each editor chooses which of these they want to focus on. Editors get auto-invited to review the changes. Timely means within a week.
 
+Editors also are responsible for managing time-sensitive merging of Pull Requests on GitHub. Sometimes, we know things have to change on a specific date. To do this, we can schedule PR merges by adding the relevant date in the opening comment of the Pull Request (editors can edit comments):
+
+```
+/schedule YYYY-MM-DD
+```
+
 As we go on this journey together, we may assign more specific responsibilities as they emerge.
 
 ## Quality standards

--- a/editors-guide.qmd
+++ b/editors-guide.qmd
@@ -22,7 +22,7 @@ Each editor commits themselves to providing timely reviews of topics, guides, or
 
 [^1]: Each editor chooses which of these they want to focus on. Editors get auto-invited to review the changes. Timely means within a week.
 
-Editors also are responsible for managing time-sensitive merging of Pull Requests on GitHub. Sometimes, we know things have to change on a specific date. To do this, we can schedule PR merges by adding the relevant date in the opening comment of the Pull Request (editors can edit comments):
+Editors also are responsible for managing time-sensitive merging of Pull Requests on GitHub. Sometimes, we know things have to change on a specific date. To do this, we can schedule PR merges by adding the relevant date in the opening comment of the Pull Request ([example](https://github.com/ubvu/open-handbook/pull/423#issue-3048403271); editors can edit comments):
 
 ```
 /schedule YYYY-MM-DD


### PR DESCRIPTION
This PR adds instructions for the editors on how to schedule a PR merge 👍

Pending the question whether we want to give all editors admin/maintain rights to be able to edit the original post.
