### PR TITLE
Introducing Blog categories and ITvO Blog

### DIFF
--- a/blog.qmd
+++ b/blog.qmd
@@ -4,6 +4,8 @@ listing:
   contents: blog
   feed: true
   sort: "date desc"
+  categories: true
+  
 ---
 
 Subscribe to the blog via  [RSS](./blog.xml).

--- a/blog/2024-05-23welcome.qmd
+++ b/blog/2024-05-23welcome.qmd
@@ -1,6 +1,7 @@
 ---
 title: Hello world!
 date: "2024-05-23"
+categories: ["Handbook"]
 ---
 
 This is the first blog entry on the Research Support Handbook. We will be posting more at a later time, and are looking forward to your contributions as well.

--- a/blog/2024-06-27hackathon.qmd
+++ b/blog/2024-06-27hackathon.qmd
@@ -14,7 +14,7 @@ author:
   - Meron Vermaas
   - Peter Vos
   - Stephanie van de Sandt
-categories: ["Handbook"]
+categories: ["Handbook","Hackathon"]
 ---
 
 On June 27th, 2024, the first hackathon for the Research Support Handbook took place with all the post authors. For this hackathon, we focused on non-GitHub based contributions, to make it as easy as possible to contribute. To make getting started with contributing easier, [we created a choose your own adventure game](https://ubvu.github.io/open-handbook/public/20240627hackathon.html). We document some lessons and clarifications below, in addition to [the twelve reported problems and suggested changes](https://github.com/ubvu/open-handbook/issues?q=created%3A2024-06-27).

--- a/blog/2024-06-27hackathon.qmd
+++ b/blog/2024-06-27hackathon.qmd
@@ -14,6 +14,7 @@ author:
   - Meron Vermaas
   - Peter Vos
   - Stephanie van de Sandt
+categories: ["Handbook"]
 ---
 
 On June 27th, 2024, the first hackathon for the Research Support Handbook took place with all the post authors. For this hackathon, we focused on non-GitHub based contributions, to make it as easy as possible to contribute. To make getting started with contributing easier, [we created a choose your own adventure game](https://ubvu.github.io/open-handbook/public/20240627hackathon.html). We document some lessons and clarifications below, in addition to [the twelve reported problems and suggested changes](https://github.com/ubvu/open-handbook/issues?q=created%3A2024-06-27).

--- a/blog/2024-09-05hackathon.qmd
+++ b/blog/2024-09-05hackathon.qmd
@@ -13,7 +13,7 @@ author:
   - Peter Vos
   - Stephanie van de Sandt
   - Tycho Hofstra
-categories: ["Handbook"]
+categories: ["Handbook","Hackathon"]
 ---
 
 On September 5th, 2024, all authors participated in the second hackathon for the Research Support Handbook. For this hackathon, we focused on quality assurance. Quality assurance is crucial in ensuring that all parties at VU Amsterdam feel confident adopting this evolving, community-led resource as an official university page. Our goal is to migrate the handbook to rdm.vu.nl in the near future, which requires us to everything is in tip-top shape.

--- a/blog/2024-09-05hackathon.qmd
+++ b/blog/2024-09-05hackathon.qmd
@@ -13,6 +13,7 @@ author:
   - Peter Vos
   - Stephanie van de Sandt
   - Tycho Hofstra
+categories: ["Handbook"]
 ---
 
 On September 5th, 2024, all authors participated in the second hackathon for the Research Support Handbook. For this hackathon, we focused on quality assurance. Quality assurance is crucial in ensuring that all parties at VU Amsterdam feel confident adopting this evolving, community-led resource as an official university page. Our goal is to migrate the handbook to rdm.vu.nl in the near future, which requires us to everything is in tip-top shape.

--- a/blog/2024-09-30hackathon.qmd
+++ b/blog/2024-09-30hackathon.qmd
@@ -11,7 +11,7 @@ author:
   - Lena Karvovskaya, UBVU
   - Stephanie van de Sandt, UBVU
   - Tycho Hofstra, UBVU
-categories: ["Handbook"]
+categories: ["Handbook","Hackathon"]
 ---
 
 In the third hackathon for the Research Support Handbook, held on September 25th, 2024, contributors gathered to make significant progress towards migrating the handbook to the VU domain (rdm.vu.nl). The event centered around sprinting to a finish line by refining existing content and ensuring accessibility standards are met.

--- a/blog/2024-09-30hackathon.qmd
+++ b/blog/2024-09-30hackathon.qmd
@@ -11,6 +11,7 @@ author:
   - Lena Karvovskaya, UBVU
   - Stephanie van de Sandt, UBVU
   - Tycho Hofstra, UBVU
+categories: ["Handbook"]
 ---
 
 In the third hackathon for the Research Support Handbook, held on September 25th, 2024, contributors gathered to make significant progress towards migrating the handbook to the VU domain (rdm.vu.nl). The event centered around sprinting to a finish line by refining existing content and ensuring accessibility standards are met.

--- a/blog/2024-10-22post-mortem.qmd
+++ b/blog/2024-10-22post-mortem.qmd
@@ -4,7 +4,7 @@ date: "2024-10-22"
 author:
   - Chris Hartgerink
   - Lena Karvovskaya
-categories: ["downtime"]
+categories: ["Handbook"]
 ---
 
 On Friday October 18th 2024, we experienced around ten hours of downtime on the `rdm.vu.nl` website. The downtime started around 10AM after merging changes to the handbook and was resolved the same day, by 8PM.[^1]

--- a/blog/2024-11-01hackathon.qmd
+++ b/blog/2024-11-01hackathon.qmd
@@ -9,7 +9,7 @@ author:
   - Elisa Rodenburg
   - Stephanie van de Sandt
 
-categories: ["hackathon"]
+categories: ["Handbook"]
 ---
 
 On October 30th, 2024, all authors participated in the fourth hackathon for the Research Support Handbook. Since the [third hackathon](https://rdm.vu.nl/blog/2024-09-30hackathon.html), we migrated to `rdm.vu.nl`, which is a huge milestone! 🎉

--- a/blog/2024-11-01hackathon.qmd
+++ b/blog/2024-11-01hackathon.qmd
@@ -9,7 +9,7 @@ author:
   - Elisa Rodenburg
   - Stephanie van de Sandt
 
-categories: ["Handbook"]
+categories: ["Handbook","Hackathon"]
 ---
 
 On October 30th, 2024, all authors participated in the fourth hackathon for the Research Support Handbook. Since the [third hackathon](https://rdm.vu.nl/blog/2024-09-30hackathon.html), we migrated to `rdm.vu.nl`, which is a huge milestone! 🎉

--- a/blog/2024-11-28hackathon.qmd
+++ b/blog/2024-11-28hackathon.qmd
@@ -8,7 +8,7 @@ author:
   - Tycho Hofstra
   - Irene Martorelli
   - Peter Vos
-categories: ["Handbook"]
+categories: ["Handbook","Hackathon"]
 ---
 
 On November 28, 2024, all authors participated in the fifth hackathon for the Research Support Handbook. For this hackathon, we focused on adding new content and consolidating requests.

--- a/blog/2024-11-28hackathon.qmd
+++ b/blog/2024-11-28hackathon.qmd
@@ -8,7 +8,7 @@ author:
   - Tycho Hofstra
   - Irene Martorelli
   - Peter Vos
-categories: ["hackathon"]
+categories: ["Handbook"]
 ---
 
 On November 28, 2024, all authors participated in the fifth hackathon for the Research Support Handbook. For this hackathon, we focused on adding new content and consolidating requests.

--- a/blog/2025-05-15embed-iframe.qmd
+++ b/blog/2025-05-15embed-iframe.qmd
@@ -1,10 +1,11 @@
 ---
 title: How to embed handbook pages using iframes
 date: "2025-05-19"
-authors:
+author:
   - Chris Hartgerink
   - Elisa Rodenburg
   - Jessica Hrudey
+categories: ["Handbook"]
 ---
 
 If you want to reuse content from the {{< var title >}}, you can do so using an HTML `iframe`. This post will help you through the steps to successfully embed a handbook page on a website you administer.

--- a/blog/2025-07-29itvoblog.qmd
+++ b/blog/2025-07-29itvoblog.qmd
@@ -9,4 +9,4 @@ author:
 
 ## First ITvO Blog
 
-Form now on the ITvO (IT for Research) team will be using the Hanbook Blog for sharing news, updates, and important announcements related to SciCloud, Ada-HPC, Scitor, and other services provided by ITvO. Here you will find information about new features, scheduled maintenance, service improvements. Stay tuned for the latest developments and insights from the ITvO team.
+From now on the [ITvO (IT for Research)](../topics/itvo.qmd) team will be using the Handbook Blog for sharing news, updates, and important announcements related to [SciCloud](../topics/scicloud.qmd), [ADA HPC](../topics/ada.qmd), [SciStor](../topics/scistor.qmd), and other services provided by ITvO. Here you will find information about new features, scheduled maintenance, service improvements. Stay tuned for the latest developments and insights from the ITvO team.

--- a/blog/2025-07-29itvoblog.qmd
+++ b/blog/2025-07-29itvoblog.qmd
@@ -1,0 +1,12 @@
+---
+title: ITvO blog
+date: "2025-07-24"
+categories: [IT for Research]
+author:
+  - Sergio Gutierrez
+  - Peter Vos
+---
+
+## First ITvO Blog
+
+Form now on the ITvO (IT for Research) team will be using the Hanbook Blog for sharing news, updates, and important announcements related to SciCloud, Ada-HPC, Scitor, and other services provided by ITvO. Here you will find information about new features, scheduled maintenance, service improvements. Stay tuned for the latest developments and insights from the ITvO team.


### PR DESCRIPTION
ITvO requested a place to post news updates. @Sergi095's and @peer35's proposal is to use the RDM blog for this. 

This change:
- adds the categories to the right sidebar of https://rdm.vu.nl/blog.html.
- adds a blog post announcing the ITvO news blog.
- categorizes existing blog posts.

We should strive to keep the category list short and useful:
- `Handbook` - pertaining to the handbook itself
- `IT for Research` - pertaining to an ITvO service or tool.
- `RDM Support` - pertaining to library RDM Support (includes functional admins).

A secondary category can be added if the blog post pertains to a particular tool, service or event. Examples:
- A post announcing an ADA upgrade: `["IT for Research", "ADA"]`
- A post announcing the new manuals section and the addition of Yoda manuals (#532): `["Handbook","Yoda"]`
- A post about a Handbook hackathon: `["Handbook","Hackathon"]`
 
We can make additional tweaks, such as adding some categories in the blog pull-down menu, at a later stage. But that doesn't feel necessary yet for the very short list of posts we have now.

Also see pull request: #515
