### PR TITLE
Add lifecycle pages containing topics + guides

### DIFF
--- a/_components/Lifecycle.jsx
+++ b/_components/Lifecycle.jsx
@@ -21,12 +21,42 @@ const CheckIcon = () => {
 
 // complete, current, upcoming
 const steps = [
-  { id: "01", name: "Discover & Initiate", href: "./guides.html#category=Discover%20%26%20Initiate", status: "upcoming" },
-  { id: "02", name: "Plan & Design", href: "./guides.html#category=Plan%20%26%20Design", status: "upcoming" },
-  { id: "03", name: "Collect & Store", href: "./guides.html#category=Collect%20%26%20Store", status: "upcoming" },
-  { id: "04", name: "Process & Analyse", href: "./guides.html#category=Process%20%26%20Analyse", status: "upcoming" },
-  { id: "05", name: "Document & Preserve", href: "./guides.html#category=Document%20%26%20Preserve", status: "upcoming" },
-  { id: "06", name: "Publish & Share", href: "./guides.html#category=Publish%20%26%20Share", status: "upcoming" },
+  {
+    id: "01",
+    name: "Discover & Initiate",
+    href: "./lifecycle/01-discover-initiate.html",
+    status: "upcoming",
+  },
+  {
+    id: "02",
+    name: "Plan & Design",
+    href: "./lifecycle/02-plan-design.html",
+    status: "upcoming",
+  },
+  {
+    id: "03",
+    name: "Collect & Store",
+    href: "./lifecycle/03-collect-store.html",
+    status: "upcoming",
+  },
+  {
+    id: "04",
+    name: "Process & Analyse",
+    href: "./lifecycle/04-process-analyse.html",
+    status: "upcoming",
+  },
+  {
+    id: "05",
+    name: "Document & Preserve",
+    href: "./lifecycle/05-document-preserve.html",
+    status: "upcoming",
+  },
+  {
+    id: "06",
+    name: "Publish & Share",
+    href: "./lifecycle/06-publish-share.html",
+    status: "upcoming",
+  },
 ];
 
 // Adapted from

--- a/lifecycle/01-discover-initiate.qmd
+++ b/lifecycle/01-discover-initiate.qmd
@@ -1,0 +1,27 @@
+---
+title: Discover & Initiate
+listing:
+  - id: topics
+    contents: "../topics/*.qmd"
+    type: table
+    table-striped: true
+    table-hover: true
+    fields: [title, reading-time]
+    include:
+      categories: "Discover & Initiate"
+  - id: guides
+    contents: "../guides/*.qmd"
+    type: grid
+    include:
+      categories: "Discover & Initiate"
+---
+
+## Topics
+
+:::{#topics}
+:::
+
+## Guides
+
+:::{#guides}
+:::

--- a/lifecycle/01-discover-initiate.qmd
+++ b/lifecycle/01-discover-initiate.qmd
@@ -3,7 +3,7 @@ title: Discover & Initiate
 listing:
   - id: topics
     contents:
-      - ../topics/ada.qmd
+      - ../topics/finding-existing-data.qmd
     type: table
     table-striped: true
     table-hover: true

--- a/lifecycle/01-discover-initiate.qmd
+++ b/lifecycle/01-discover-initiate.qmd
@@ -2,13 +2,12 @@
 title: Discover & Initiate
 listing:
   - id: topics
-    contents: "../topics/*.qmd"
+    contents:
+      - ../topics/ada.qmd
     type: table
     table-striped: true
     table-hover: true
     fields: [title, reading-time]
-    include:
-      categories: "Discover & Initiate"
   - id: guides
     contents: "../guides/*.qmd"
     type: grid

--- a/lifecycle/02-plan-design.qmd
+++ b/lifecycle/02-plan-design.qmd
@@ -1,0 +1,27 @@
+---
+title: Plan & Design
+listing:
+  - id: topics
+    contents: "../topics/*.qmd"
+    type: table
+    table-striped: true
+    table-hover: true
+    fields: [title, reading-time]
+    include:
+      categories: "Plan & Design"
+  - id: guides
+    contents: "../guides/*.qmd"
+    type: grid
+    include:
+      categories: "Plan & Design"
+---
+
+## Topics
+
+:::{#topics}
+:::
+
+## Guides
+
+:::{#guides}
+:::

--- a/lifecycle/02-plan-design.qmd
+++ b/lifecycle/02-plan-design.qmd
@@ -2,13 +2,12 @@
 title: Plan & Design
 listing:
   - id: topics
-    contents: "../topics/*.qmd"
+    contents:
+      - ../topics/ada.qmd
     type: table
     table-striped: true
     table-hover: true
     fields: [title, reading-time]
-    include:
-      categories: "Plan & Design"
   - id: guides
     contents: "../guides/*.qmd"
     type: grid

--- a/lifecycle/02-plan-design.qmd
+++ b/lifecycle/02-plan-design.qmd
@@ -3,7 +3,12 @@ title: Plan & Design
 listing:
   - id: topics
     contents:
-      - ../topics/ada.qmd
+      - ../topics/data-classification.qmd
+      - ../topics/data-management-plan.qmd
+      - ../topics/data-management-section.qmd
+      - ../topics/ethical-review.qmd
+      - ../topics/gdpr.qmd
+      - ../topics/research-data-and-software-management-policy.qmd
     type: table
     table-striped: true
     table-hover: true

--- a/lifecycle/03-collect-store.qmd
+++ b/lifecycle/03-collect-store.qmd
@@ -2,13 +2,12 @@
 title: Collect & Store
 listing:
   - id: topics
-    contents: "../topics/*.qmd"
+    contents:
+      - ../topics/ada.qmd
     type: table
     table-striped: true
     table-hover: true
     fields: [title, reading-time]
-    include:
-      categories: "Collect & Store"
   - id: guides
     contents: "../guides/*.qmd"
     type: grid

--- a/lifecycle/03-collect-store.qmd
+++ b/lifecycle/03-collect-store.qmd
@@ -3,7 +3,15 @@ title: Collect & Store
 listing:
   - id: topics
     contents:
-      - ../topics/ada.qmd
+      - ../topics/data-collection.qmd
+      - ../topics/qualtrics.qmd
+      - ../topics/data-storage.qmd
+      - ../topics/data-backup.qmd
+      - ../topics/data-protection.qmd
+      - ../topics/safe-data-transfer.qmd
+      - ../topics/researchdrive.qmd
+      - ../topics/scistor.qmd
+      - ../topics/yoda.qmd
     type: table
     table-striped: true
     table-hover: true

--- a/lifecycle/03-collect-store.qmd
+++ b/lifecycle/03-collect-store.qmd
@@ -1,0 +1,27 @@
+---
+title: Collect & Store
+listing:
+  - id: topics
+    contents: "../topics/*.qmd"
+    type: table
+    table-striped: true
+    table-hover: true
+    fields: [title, reading-time]
+    include:
+      categories: "Collect & Store"
+  - id: guides
+    contents: "../guides/*.qmd"
+    type: grid
+    include:
+      categories: "Collect & Store"
+---
+
+## Topics
+
+:::{#topics}
+:::
+
+## Guides
+
+:::{#guides}
+:::

--- a/lifecycle/04-process-analyse.qmd
+++ b/lifecycle/04-process-analyse.qmd
@@ -4,6 +4,11 @@ listing:
   - id: topics
     contents:
       - ../topics/ada.qmd
+      - ../topics/compute-hub.qmd
+      - ../topics/researchcloud.qmd
+      - ../topics/safe-data-transfer.qmd
+      - ../topics/scicloud.qmd
+      - ../topics/snellius.qmd
     type: table
     table-striped: true
     table-hover: true

--- a/lifecycle/04-process-analyse.qmd
+++ b/lifecycle/04-process-analyse.qmd
@@ -2,13 +2,12 @@
 title: Process & Analyse
 listing:
   - id: topics
-    contents: "../topics/*.qmd"
+    contents:
+      - ../topics/ada.qmd
     type: table
     table-striped: true
     table-hover: true
     fields: [title, reading-time]
-    include:
-      categories: "Process & Analyse"
   - id: guides
     contents: "../guides/*.qmd"
     type: grid

--- a/lifecycle/04-process-analyse.qmd
+++ b/lifecycle/04-process-analyse.qmd
@@ -1,0 +1,27 @@
+---
+title: Process & Analyse
+listing:
+  - id: topics
+    contents: "../topics/*.qmd"
+    type: table
+    table-striped: true
+    table-hover: true
+    fields: [title, reading-time]
+    include:
+      categories: "Process & Analyse"
+  - id: guides
+    contents: "../guides/*.qmd"
+    type: grid
+    include:
+      categories: "Process & Analyse"
+---
+
+## Topics
+
+:::{#topics}
+:::
+
+## Guides
+
+:::{#guides}
+:::

--- a/lifecycle/05-document-preserve.qmd
+++ b/lifecycle/05-document-preserve.qmd
@@ -2,13 +2,12 @@
 title: Document & Preserve
 listing:
   - id: topics
-    contents: "../topics/*.qmd"
+    contents:
+      - ../topics/ada.qmd
     type: table
     table-striped: true
     table-hover: true
     fields: [title, reading-time]
-    include:
-      categories: "Document & Preserve"
   - id: guides
     contents: "../guides/*.qmd"
     type: grid

--- a/lifecycle/05-document-preserve.qmd
+++ b/lifecycle/05-document-preserve.qmd
@@ -3,7 +3,15 @@ title: Document & Preserve
 listing:
   - id: topics
     contents:
-      - ../topics/ada.qmd
+      - ../topics/data-archiving.qmd
+      - ../topics/data-documentation.qmd
+      - ../topics/fair-principles.qmd
+      - ../topics/metadata.qmd
+      - ../topics/persistent-identifier.qmd
+      - ../topics/selecting-data.qmd
+      - ../topics/software-archiving.qmd
+      - ../topics/dataversenl.qmd
+      - ../topics/yoda.qmd
     type: table
     table-striped: true
     table-hover: true

--- a/lifecycle/05-document-preserve.qmd
+++ b/lifecycle/05-document-preserve.qmd
@@ -1,0 +1,27 @@
+---
+title: Document & Preserve
+listing:
+  - id: topics
+    contents: "../topics/*.qmd"
+    type: table
+    table-striped: true
+    table-hover: true
+    fields: [title, reading-time]
+    include:
+      categories: "Document & Preserve"
+  - id: guides
+    contents: "../guides/*.qmd"
+    type: grid
+    include:
+      categories: "Document & Preserve"
+---
+
+## Topics
+
+:::{#topics}
+:::
+
+## Guides
+
+:::{#guides}
+:::

--- a/lifecycle/06-publish-share.qmd
+++ b/lifecycle/06-publish-share.qmd
@@ -1,0 +1,27 @@
+---
+title: Publish & Share
+listing:
+  - id: topics
+    contents: "../topics/*.qmd"
+    type: table
+    table-striped: true
+    table-hover: true
+    fields: [title, reading-time]
+    include:
+      categories: "Publish & Share"
+  - id: guides
+    contents: "../guides/*.qmd"
+    type: grid
+    include:
+      categories: "Publish & Share"
+---
+
+## Topics
+
+:::{#topics}
+:::
+
+## Guides
+
+:::{#guides}
+:::

--- a/lifecycle/06-publish-share.qmd
+++ b/lifecycle/06-publish-share.qmd
@@ -2,13 +2,12 @@
 title: Publish & Share
 listing:
   - id: topics
-    contents: "../topics/*.qmd"
+    contents:
+      - ../topics/ada.qmd
     type: table
     table-striped: true
     table-hover: true
     fields: [title, reading-time]
-    include:
-      categories: "Publish & Share"
   - id: guides
     contents: "../guides/*.qmd"
     type: grid

--- a/lifecycle/06-publish-share.qmd
+++ b/lifecycle/06-publish-share.qmd
@@ -3,7 +3,17 @@ title: Publish & Share
 listing:
   - id: topics
     contents:
-      - ../topics/ada.qmd
+      - ../topics/fair-principles.qmd
+      - ../topics/persistent-identifier.qmd
+      - ../topics/data-publishing.qmd
+      - ../topics/software-publishing.qmd
+      - ../topics/data-licensing.qmd
+      - ../topics/software-licensing.qmd
+      - ../topics/data-registration.qmd
+      - ../topics/software-registration.qmd
+      - ../topics/dataversenl.qmd
+      - ../topics/osf.qmd
+      - ../topics/yoda.qmd
     type: table
     table-striped: true
     table-hover: true


### PR DESCRIPTION
- **add lifecycle pages**
- **update links from frontpage**

Open questions that remain are:

- Does the ordering of Topics first and Guides second make sense?
- Topics do not yet have categories for the lifecycle relevance - these need to be added.

