### PR TITLE
Include-manuals-homepage

### DIFF
--- a/_components/Cta.jsx
+++ b/_components/Cta.jsx
@@ -25,6 +25,12 @@ function Cta() {
               >
                 View guides
               </a>
+              <a
+                href="./manuals.html"
+                className="tw-text-sm tw-font-semibold tw-leading-6 tw-text-white"
+              >
+                View manuals
+              </a>
             </div>
           </div>
         </div>

--- a/_components/Features.jsx
+++ b/_components/Features.jsx
@@ -77,7 +77,7 @@ const features = [
   },
   {
     name: "Flexible",
-    description: "Shape the content to your needs. Find topics or guides.",
+    description: "Shape the content to your needs. Find topics, guides or manuals.",
     icon: () => (
       <svg
         xmlns="http://www.w3.org/2000/svg"

--- a/_components/Hero.jsx
+++ b/_components/Hero.jsx
@@ -4,7 +4,7 @@ function Hero() {
       <div className="tw-mx-auto tw-max-w-2xl tw-py-16">
         <div className="tw-hidden sm:tw-mb-8 sm:tw-flex sm:tw-justify-center">
           <div className="tw-relative tw-rounded-full tw-px-3 tw-py-1 tw-text-sm tw-leading-6 tw-text-gray-600 tw-ring-1 tw-ring-gray-900/10 hover:tw-ring-gray-900/20">
-            This is a new project. Missing something?{" "}
+            We update this website regularly. Missing something?{" "}
             <a href="https://ez-github-contributor.netlify.app/" className="tw-font-semibold tw-text-sky-600">
               <span className="tw-absolute tw-inset-0" aria-tw-hidden="true" />
               Let us know <span aria-tw-hidden="true">&rarr;</span>
@@ -16,7 +16,7 @@ function Hero() {
             Find quality information on research practices at VU Amsterdam
           </h1>
           <p className="tw-mt-6 tw-text-base tw-leading-8 tw-text-gray-600">
-            The Research Support Handbook helps you learn about topics relevant to your research. It also guides you through specific issues you might encounter in your modern day research. All of the information on these pages is curated by VU staff, for VU staff. The handbook is updated on a daily basis.
+            The Research Support Handbook helps you learn about topics relevant to your research. It also guides you through specific issues you might encounter in your modern day research. There are tool-specific how-to manuals as well. All of the information on these pages is curated by VU staff, for VU staff. The handbook is updated on a daily basis.
           </p>
           <div className="tw-mt-10 tw-flex tw-items-center tw-justify-center tw-gap-x-6">
             <a
@@ -30,6 +30,12 @@ function Hero() {
               className="tw-text-sm tw-font-semibold tw-leading-6 tw-text-gray-900"
             >
               View guides
+            </a>
+            <a
+              href="./manuals.html"
+              className="tw-text-sm tw-font-semibold tw-leading-6 tw-text-gray-900"
+            >
+              View manuals
             </a>
           </div>
         </div>

--- a/_components/Lifecycle.jsx
+++ b/_components/Lifecycle.jsx
@@ -70,7 +70,7 @@ function Lifecycle() {
             Research Life Cycle
           </h2>
           <p className="tw-m-6 tw-text-lg tw-leading-8 tw-text-gray-600">
-            Find the relevant guides for the stage of your research.
+            Find the relevant information for the stage of your research.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Where relevant, I added references to the manuals on the homepage. I also changed some descriptions, so that they align with the new structure and with the new life cycle pages, which now include both topics and guides.