### PR TITLE
Make links open in a new tab

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -90,5 +90,6 @@ format:
 # from: "markdown+emoji"
 filters:
   - utils/include-files.lua
+  - utils/linktarget.lua
 execute:
   freeze: auto

--- a/utils/linktarget.lua
+++ b/utils/linktarget.lua
@@ -1,0 +1,9 @@
+--- linktarget.lua – add "target='_blank'" to external links so they open in a new tab
+--- Peter Vos, 2025-09-11
+
+function Link(link)
+    if link.target:match '^https?%:' then
+      link.attributes.target = '_blank'
+      return link
+    end
+end


### PR DESCRIPTION
On rendering `target="blank"` will be added to _external_ links in the HTML so they open in a new tab when clicked. 

Closes #570