### PR TITLE
possible fix of inappropriate suggestions after Yoda video

### DIFF
--- a/topics/yoda.qmd
+++ b/topics/yoda.qmd
@@ -6,7 +6,7 @@ categories: [Tools]
 ## What is it?
 Yoda is an application for institutions that supports Research Data Management (RDM) throughout the entire research cycle: from the safe and easy storage and sharing of data during the research process, to the sharing of data within research collaborations and ultimately to research data archiving and publication.
 
-{{< video https://www.youtube.com/embed/N67v2v62Qn0?si=MhjAv6lDHAyCgfUy >}}
+{{< video https://www.youtube.com/embed/N67v2v62Qn0?rel=0 >}}
 
 Yoda helps the researcher make their data "[FAIR](../topics/fair-principles.qmd)" by providing a solution that enables data discovery and sharing (i.e., findable, accessible). In addition, it facilitates the use of metadata, contributing to data interoperability and reusability. Yoda provides a platform for the implementation of standard workflows that can ensure metadata quality satisfying [VU policy requirements](../topics/research-data-and-software-management-policy.qmd) for data archiving and publication. In addition, Yoda is built on [iRODS](https://irods.org) so it accommodates both researchers with data heavy requirements, as well as those seeking an accessible, user-friendly solution.
 


### PR DESCRIPTION
Adding `?rel=0` to the url in a Youtube embed limits the suggestions you see after the video finishes to the channel the video is in. With this change the visitor should see VU videos as suggestions instead of random, sometimes inappropriate, Youtube videos.

See https://developers.google.com/youtube/player_parameters#rel

(the `si` parameter didn't seem to do anything so I've removed it)