### PR TITLE
add reference to gocommands

### DIFF
--- a/manuals/yoda/data_access/yoda_using_icommands.qmd
+++ b/manuals/yoda/data_access/yoda_using_icommands.qmd
@@ -20,7 +20,7 @@ There is no officially supported iCommands installation for Mac OSX, you could i
 ::: { .callout-tip }
 **gocommands** is an alternative command-line client you could try if your OS does not support iCommands. 
 
-The `readme.md` on the [github repository](https://github.com/cyverse/gocommands) has installation instructions. Once installed you can use the common iCommands as `gocmd <command>`, e.g. `gocmd ls`, `gocmd get`, `gocmd put`, `gocmd rsync`
+The `readme.md` on the [github repository](https://github.com/cyverse/gocommands) has installation instructions. You can find the details of creating the irods environment file [below](#environment-file). Once installed you can execute common iCommands as `gocmd <command>`, e.g. `gocmd init`, `gocmd ls`, `gocmd get`, `gocmd put`, `gocmd rsync`.
 :::
 
 ### Installing iCommands on CentOS


### PR DESCRIPTION
Small change to the Yoda iCommands manual. gocommands is an alternative commandline tool for people who'd like to use the CLI but are using an unsupported OS. 

part of #547 