### PR TITLE
Fix markdown link formatting in FAQ

### DIFF
--- a/manuals/yoda/faq/faq.qmd
+++ b/manuals/yoda/faq/faq.qmd
@@ -9,7 +9,7 @@ YODA is an application for institutions that supports RDM throughout the entire 
 
 ### How do I Request Project Space on Yoda?
 
-Every VU researcher can request storage space for their projects in Yoda. Requesting space is done via a request form. Please note that because there can be costs involved, you need to supply a budget code. You can find more about the costs involved in the [Cost Model] (https://vu.nl/en/employee/research-data-support/research-archiving-storage-cost-model).
+Every VU researcher can request storage space for their projects in Yoda. Requesting space is done via a request form. Please note that because there can be costs involved, you need to supply a budget code. You can find more about the costs involved in the [Cost Model](https://vu.nl/en/employee/research-data-support/research-archiving-storage-cost-model).
 
 ### How do I Access Yoda?
 
@@ -42,12 +42,12 @@ When in doubt about what type of data you’re dealing with, please consult your
 
 ### What else can I do on Yoda besides Data Storage?
 
-It supports the entire research process from data acquisition to publication. It enables data publication and the associated minting of persistent identifiers (DOIs). It offers support for standardised workflows for the storage and archiving of research data. You can find more information in the [Yoda Topic Page] (https://rdm.vu.nl/topics/yoda.html). 
+It supports the entire research process from data acquisition to publication. It enables data publication and the associated minting of persistent identifiers (DOIs). It offers support for standardised workflows for the storage and archiving of research data. You can find more information in the [Yoda Topic Page](https://rdm.vu.nl/topics/yoda.html). 
 
 ### What is Metadata? And why is it Important when Using Yoda?
 
 Metadata is “data about data”. Metadata serves multiple purposes in Yoda. 
-Yoda facilitates adding both structured and unstructured metadata to your research data. Entering structured metadata is a prerequisite for archiving a data package. If a folder is published, its structured metadata will be published as well and can be harvested by data catalogs such as DANS NARCIS and DataCite. You can find more information about Metadata [here] (https://rdm.vu.nl/manuals/yoda/using_yoda/metadata.html).
+Yoda facilitates adding both structured and unstructured metadata to your research data. Entering structured metadata is a prerequisite for archiving a data package. If a folder is published, its structured metadata will be published as well and can be harvested by data catalogs such as DANS NARCIS and DataCite. You can find more information about Metadata [here](https://rdm.vu.nl/manuals/yoda/using_yoda/metadata.html).
 
 ### What is a Data Package?
 
@@ -55,12 +55,12 @@ The data in your research data compartment is a set of files and folders. If par
 
 ### How does Archiving works in Yoda?
 
-If you choose to archive a part of your data, Yoda will make a copy of the data to the archive (also known as “Vault”) of your project space, where it will be retained unchanged during its retention period. You can visit the [Vault Page] (https://rdm.vu.nl/manuals/yoda/securing_distribution/vault_archive.html) for more information about archiving data.
+If you choose to archive a part of your data, Yoda will make a copy of the data to the archive (also known as “Vault”) of your project space, where it will be retained unchanged during its retention period. You can visit the [Vault Page](https://rdm.vu.nl/manuals/yoda/securing_distribution/vault_archive.html) for more information about archiving data.
 
 ### How Do I Submit a Data Package to The Vault?
 
 Only Group Manager or regular group members may submit data packages to the Vault.
-Navigate to the folder you want to archive in the Yoda portal. Ensure that you are in the folder which you want to submit to the vault. Check that all mandatory metadata has been entered in the metadata form of the folder. Now press the “Actions (Submit)” button. You can visit the [Vault Page] (https://rdm.vu.nl/manuals/yoda/securing_distribution/vault_archive.html) for more information about archiving data.
+Navigate to the folder you want to archive in the Yoda portal. Ensure that you are in the folder which you want to submit to the vault. Check that all mandatory metadata has been entered in the metadata form of the folder. Now press the “Actions (Submit)” button. You can visit the [Vault Page](https://rdm.vu.nl/manuals/yoda/securing_distribution/vault_archive.html) for more information about archiving data.
 
 
 ### What is the Role of the Data Manager?
@@ -77,7 +77,7 @@ After archiving your data, you can optionally publish it, thus making your data 
 
 ### How Do I Make My Data Package Ready for Publication?
 
-If needed, you can update the metadata by clicking the “Metadata” button. To submit a data package for publication, navigate to the data package in the vault and press the “Submit for publication” button. For more information on submitting a dataset for publication you can visit [Publishing Data] (https://rdm.vu.nl/manuals/yoda/securing_distribution/vault_publish.html).
+If needed, you can update the metadata by clicking the “Metadata” button. To submit a data package for publication, navigate to the data package in the vault and press the “Submit for publication” button. For more information on submitting a dataset for publication you can visit [Publishing Data](https://rdm.vu.nl/manuals/yoda/securing_distribution/vault_publish.html).
 
 ### What is the Process of Data Review for Publication?
 


### PR DESCRIPTION
# Pull Request Checklist

## General Writing Standards

### Voice and Clarity
- [ ] Text is primarily written in active voice
- [ ] Acronyms are written in full at least once on the page where they are used
- [ ] We refer to Handbook topics where possible (e.g. to the Handbook page about Yoda instead of some other information page about Yoda)

### Links and Referencing
- [ ] All links use `https://` protocol
- [ ] Links are descriptive (avoid "click here" links)
- [ ] For pages with a DOI, link through the DOI (e.g., `https://doi.org/10.4444/xxxx`)

### Images
- [ ] All images have descriptive alt text

### Tone and Style
- [ ] Avoid writing in the name of the handbook (no "we recommend")

## Topic-Specific Standards

- [ ] Topics are nouns or noun phrases
- [ ] Topics are self-contained and concise
- [ ] Topics are title capitalized
- [ ] No `include` statements in topics
- [ ] Only use regular markdown (no special Quarto code)
- [ ] Where relevant, assign a suitable category

## Guide-Specific Standards

- [ ] Guides are phrased as questions the reader will find answers to
- [ ] Where relevant, guides are assigned a suitable category

## Checklist Usage
- Fill out this checklist when submitting a pull request
- Automated checks will verify some of these standards, but manual review is still crucial

*Note to Contributors: Thank you for helping maintain the quality of our handbook!*
