### PR TITLE
smaller compliance screenshot in Yoda archiving manual

### DIFF
--- a/manuals/yoda/securing_distribution/vault_archive.qmd
+++ b/manuals/yoda/securing_distribution/vault_archive.qmd
@@ -32,7 +32,7 @@ You can check in Yoda if you are in compliance with either the DANS Preferred fo
 
 Choose a preferred fomat and the system will show you a list of filetypes in your data folder which are not compliant.
 
-![Check for DANS compliance](/public/manuals/yoda/arch-compliance-dans.png)
+![Check for DANS compliance](/public/manuals/yoda/arch-compliance-dans.png){width=300}
 
 ## How to: Submitting a data package to the Vault
 


### PR DESCRIPTION
Add `{width=<# of pixels>}` after a link to change the size the of an image on the page. The height is calculated automatically so the image is not distorted. Setting `height=<#of pixels>` works as well, see: https://quarto.org/docs/authoring/figures.html#figure-sizing

In this case:
```
![Check for DANS compliance](/public/manuals/yoda/arch-compliance-dans.png){width=300}
```
looks better. there are probably more screenshots in the Yoda manual that could do with some resizing.