### PR TITLE
Custom Guides List proof of concept

### DIFF
--- a/expandable-details.ejs
+++ b/expandable-details.ejs
@@ -1,5 +1,13 @@
-<ul>
-    <% for (const item of items) { %>
-      <li><a href="<%- item.path %>"><%= item.title %></a></li>
+<ul class="vu-listing list">
+  <% for (const item of items) { %>
+    <li <%= metadataAttrs(item) %>>
+      <details>
+        <summary>
+          <span class="listing-title"><%= item.title %></span>
+        </summary>
+          <span class="listing-description>"><%= item.description %></span><br>
+          <a href="<%- item.path %>">Read more</a>
+      </details>
+    </li>
     <% } %>
 </ul>

--- a/guides.qmd
+++ b/guides.qmd
@@ -1,14 +1,24 @@
 ---
 title: "Guides"
 listing:
+  template: expandable-details.ejs # ejs is sensitive to indentation, use 2 spaces
   contents: guides
-  type: grid
   categories: true
 include-in-header:
   text: |
     <style type="text/css">
     .quarto-grid-item .listing-item-img-placeholder {
       background-color: #0080c9;
+    }
+    ul.vu-listing {
+      list-style-type: none;
+      list-style-position: inside;
+      padding-left: 0;
+    }
+    ul.vu-listing li {
+      border-bottom: 1px solid #0080c9;
+      margin-bottom: 10px;
+      padding-left: 20px;
     }
     </style>
 ---


### PR DESCRIPTION
Following the discussion on February 3, where the question rose if it was possible to style the Guides list like lists on the VU website (e.g. just show the titles, clicking on a title expands to a larger description). This is just an example, does not need to be merged. Issue #710 

Uses a custom EJS template (https://ejs.co/#docs) to leverage the custom listing functionality: https://quarto.org/docs/websites/website-listings-custom.html

Notes:
- This example was made using the standard HTML `<details>` and `<summary>` tags and minimal css styling. 
- If needed more advanced styling is possible using bootstrap (e.g. https://getbootstrap.com/docs/5.0/components/accordion/).
- Note that the contents of a listing use metadata set in the guide pages (title, description, image, category). Custom fields could be added.

Preview: https://deploy-preview-711--ub-open-handbook.netlify.app/guides