### PR TITLE
Changed URL to page about transcription services

### DIFF
--- a/guides/process-and-analyse.qmd
+++ b/guides/process-and-analyse.qmd
@@ -50,7 +50,7 @@ It is common in many fields to hold interviews, focus group sessions, or make ot
 
 Another option is to pay a transcription service to make the transcription or to use specialised software. VU Amsterdam has drawn up processing agreements with one transcription service, [Transcript Online](https://transcriptonline.nl), and one transcription software service, [Amberscript](https://www.amberscript.com/en/).
 
-You can find more information on the [VU Library page](https://vu.nl/en/about-vu/divisions/university-library/more-about/transcription%20at%20vu) on what these transcription options do, how they work, how much they cost, and how they can be used.
+You can find more information on the page [Transcription Services](../topics/transcription.qmd) on what these transcription options do, how they work, how much they cost, and how they can be used.
 
 ### Anonymisation/Pseudonymisation
 


### PR DESCRIPTION
From [VU page](https://vu.nl/en/about-vu/divisions/university-library/more-about/transcription-at-vu-for-audio-and-video-files) to Handbook topic [Transcription Services](../topics/transcription.qmd)
