### PR TITLE
Move Trainings page to root folder

### DIFF
--- a/trainings.qmd
+++ b/trainings.qmd
@@ -1,6 +1,5 @@
 ---
 title: Trainings
-categories: [Trainings and Knowledge Items]
 ---
 
 It is easy to get overwhelmed with all the trainings available. On this page we provide a list of trainings available.


### PR DESCRIPTION
- Take Trainings page out of Topics, move to root folder. Once this step has been completed, refer to new location from Home page under 'Related Trainings and Events'.
- Removed topics category

Fixes #722