### PR TITLE
extra div around description

### DIFF
--- a/_templates/accordion-logo.ejs.md
+++ b/_templates/accordion-logo.ejs.md
@@ -25,7 +25,9 @@
                                     </div>
                                 <% } %>
                                 <a href="<%- item.path %>">
-                                    <span class="listing-description"><%= item.description %></span><br>
+                                    <div>
+                                        <span class="listing-description"><%= item.description %></span><br>
+                                    </div>
                                 </a>
                             </div>
                             <div class="column" style="width: 30%;">

--- a/_templates/accordion.ejs.md
+++ b/_templates/accordion.ejs.md
@@ -23,7 +23,9 @@
                         </div>
                     <% } %>
                     <a href="<%- item.path %>">
-                        <span class="listing-description"><%= item.description %></span><br>
+                        <div>
+                            <span class="listing-description"><%= item.description %></span><br>
+                        </div>
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
Small improvement to the listing on the Topics, Guides and Tools pages. 

Makes it easier to click on the description to go to the page. Currently the area between 2 lines of text is not clickable.