### PR TITLE
Correct cost description for project folder usage

### DIFF
--- a/tools/scistor/cost_access.qmd
+++ b/tools/scistor/cost_access.qmd
@@ -30,4 +30,4 @@ You can find an explanation of the pemission structure in the [documentation](ho
 
 ## Are there costs involved?
 
-You pay for the amount of space reserved for your project folder: €0,16 per GB per year.
+You pay for the amount of space used for your project folder: €0,16 per GB per year.


### PR DESCRIPTION
changed from:

"""
you pay for the amount of space reserved
"""

To:
"""
you pay for the amount of space used
"""
