### PR TITLE
Update category knowledge items

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -34,8 +34,8 @@ website:
             href: /topics.html#category=Research%20Software
           - text: Responsible Scholarship
             href: /topics.html#category=Responsible%20Scholarship
-          - text: Trainings and Knowledge Items
-            href: /topics.html#category=Trainings%20and%20Knowledge%20Items
+          - text: Knowledge Items
+            href: /topics.html#category=Knowledge%20Items
       - text: Guides
         file: guides.qmd
       - text: Tools

--- a/topics/itvo.qmd
+++ b/topics/itvo.qmd
@@ -1,6 +1,6 @@
 ---
 title: IT for Research (ITvO)
-categories: [Trainings and Knowledge Items]
+categories: [Knowledge Items]
 ---
 
 ITvO (IT voor Onderzoek, IT for Research) is a dedicated team within the university IT department, focused on supporting researchers with IT solutions. We bridge the gap between research needs and IT possibilities, making sure researchers have access to the right tools, infrastructure, and expertise.

--- a/topics/rdm-support-desk.qmd
+++ b/topics/rdm-support-desk.qmd
@@ -1,6 +1,6 @@
 ---
 title: RDM Support Desk
-categories: [Trainings and Knowledge Items]
+categories: [Knowledge Items]
 ---
 
 ::: {.callout-tip}

--- a/topics/rdsm-terminology.qmd
+++ b/topics/rdsm-terminology.qmd
@@ -1,6 +1,6 @@
 ---
 title: Research Data and Software Management Terminology
-categories: [Trainings and Knowledge Items]
+categories: [Knowledge Items]
 ---
 
 ## What is RDSM Terminology?

--- a/topics/research-data-management.qmd
+++ b/topics/research-data-management.qmd
@@ -1,6 +1,6 @@
 ---
 title: Research Data Management (RDM)
-categories: [Trainings and Knowledge Items]
+categories: [Knowledge Items]
 ---
 
 <!-- markdownlint-disable MD033 -->


### PR DESCRIPTION
Remove 'trainings' from topic category 'Trainings and Knowledge Items', because we decided to move the trainings page to another location (so no longer a topic). Hence, the remaining topics in the category can be better categorized as 'Knowledge Items'.