### PR TITLE
Update formatting pre-registration.qmd

### DIFF
--- a/topics/pre-registration.qmd
+++ b/topics/pre-registration.qmd
@@ -58,10 +58,12 @@ By documenting hypotheses, sample size, exclusion criteria, and analytic strateg
 There are two main forms of preregistration:
 
 1. **Unreviewed preregistration**
-   Researchers publicly register their research plan before data collection. When the study is later submitted for publication, reviewers and readers can assess how well the reported analyses match the preregistered plan.
+
+Researchers publicly register their research plan before data collection. When the study is later submitted for publication, reviewers and readers can assess how well the reported analyses match the preregistered plan.
 
 2. **Reviewed preregistration (Registered Reports)**
-   Researchers submit a detailed research proposal to a journal **prior to data collection**. The proposal undergoes peer review, and the journal may offer in-principle acceptance based on the study’s **theoretical motivation and methodological rigor**, rather than its results.
+
+Researchers submit a detailed research proposal to a journal prior to data collection. The proposal undergoes peer review, and the journal may offer in-principle acceptance based on the study’s theoretical motivation and methodological rigor, rather than its results.
 
 ---
 


### PR DESCRIPTION
formatting issue in types of pre-registration. Should look better now

# Pull Request Checklist

## General Writing Standards

### Voice and Clarity
- [x] Text is primarily written in active voice
- [x] Acronyms are written in full at least once on the page where they are used
- [x] We refer to Handbook topics where possible (e.g. to the Handbook page about Yoda instead of some other information page about Yoda)

### Links and Referencing
- [x] All links use `https://` protocol
- [x] Links are descriptive (avoid "click here" links)
- [x] For pages with a DOI, link through the DOI (e.g., `https://doi.org/10.4444/xxxx`)

### Images
- [x] All images have descriptive alt text

### Tone and Style
- [x] Avoid writing in the name of the handbook (no "we recommend")

## Topic-Specific Standards

- [x] Topics are nouns or noun phrases
- [x] Topics are self-contained and concise
- [x] Topics are title capitalized
- [x] No `include` statements in topics
- [x] Only use regular markdown (no special Quarto code)
- [x] Where relevant, assign a suitable category

## Guide-Specific Standards

- [ ] Guides are phrased as questions the reader will find answers to
- [ ] Where relevant, guides are assigned a suitable category

## Checklist Usage
- Fill out this checklist when submitting a pull request
- Automated checks will verify some of these standards, but manual review is still crucial

*Note to Contributors: Thank you for helping maintain the quality of our handbook!*
