### PR TITLE
remove body font-weight

### DIFF
--- a/custom.scss
+++ b/custom.scss
@@ -14,7 +14,6 @@ $accordion-button-focus-box-shadow: none;
 body {
     font-family: 'Roboto';
     line-height: 1.6666666667rem;
-    font-weight: 300;
 }
 
 .fixed-top {


### PR DESCRIPTION
I noticed bold text is not really bold. This was an unwanted side-effect of a change to `body` `font-weight` I made during the redesign. 

Removing it does not visibly affect the look of the site, but does restore the visible difference between normal and **bold** text.

Closes #820 