### PR TITLE
Bug fix: include-in-header as array 

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -71,7 +71,7 @@ format:
       text: |
         <div class="handbook-title">Research Support Handbook</div>
     include-in-header:
-      text: <script defer src="https://umami.labs.vu.nl/script.js" data-website-id="d8c5a441-b2ab-4d33-ba3a-6647fd821974"></script>
+      - text: <script defer src="https://umami.labs.vu.nl/script.js" data-website-id="d8c5a441-b2ab-4d33-ba3a-6647fd821974"></script>
 # from: "markdown+emoji"
 filters:
   - utils/include-files.lua

--- a/guides.qmd
+++ b/guides.qmd
@@ -9,15 +9,15 @@ listing:
   template-params:
     type: Guide
 include-in-header:
-  text: |
-    <style type="text/css">
-    .handbook-title {
-      text-align: center;
-    }
-    #title-block-header {
-      display: none;
-    }
-    </style>
+  - text: |
+      <style type="text/css">
+      .handbook-title {
+        text-align: center;
+      }
+      #title-block-header {
+        display: none;
+      }
+      </style>
 ---
 ::: {.guides-main}
 ::: {.text-center .px-5}

--- a/tools.qmd
+++ b/tools.qmd
@@ -27,18 +27,16 @@ listing:
   image-align: right
   template-params:
     type: Tool
-format: 
-  html:
-    include-in-header:  
-      text: |
-        <style>
-        .handbook-title {
-          text-align: center;
-        }
-        #title-block-header {
-          display: none;
-        }
-        </style>
+include-in-header:  
+  - text: |
+      <style>
+      .handbook-title {
+        text-align: center;
+      }
+      #title-block-header {
+        display: none;
+      }
+      </style>
 ---
 
 ::: {.tools-main}

--- a/topics.qmd
+++ b/topics.qmd
@@ -9,15 +9,15 @@ listing:
   template-params:
     type: Topic
 include-in-header:
-  text: |
-    <style>
-    .handbook-title {
-      text-align: center;
-    }
-    #title-block-header {
-      display: none;
-    }
-    </style>
+  - text: |
+      <style>
+      .handbook-title {
+        text-align: center;
+      }
+      #title-block-header {
+        display: none;
+      }
+      </style>
 ---
 ::: {.topics-main}
 ::: {.text-center .px-5}


### PR DESCRIPTION
The Guides, Topics and Tool pages were missing from the Umami statistics, this fixes.

Closes #834 