### PR TITLE
Rdm tools topic with filtered list

### DIFF
--- a/topics/rdm-tools.qmd
+++ b/topics/rdm-tools.qmd
@@ -27,41 +27,19 @@ include-in-header:
           color: #fff;
           border-color: var(--bs-primary, #0077b3);
         }
-        .tool-header { cursor: pointer; user-select: none; }
-        .tool-header:hover h2 { opacity: 0.8; }
-        .tool-toggle {
-          display: inline-block;
-          font-size: 0.6em;
-          color: var(--bs-secondary, #6c757d);
-          transition: transform 0.15s;
-          vertical-align: middle;
-          margin-right: 0.3em;
-        }
-        .tool-section[data-open="true"] .tool-toggle { transform: rotate(90deg); }
-        .tool-body {
-          padding-left: 1rem;
-          border-left: 3px solid var(--bs-border-color, #dee2e6);
-          margin-bottom: 1rem;
-        }
         </style>
         <script>
-        const __searchQuery = new URLSearchParams(window.location.search).get('q');
-        const __textFragment = decodeURIComponent(
-            window.location.hash.match(/#:~:text=([^&]*)/)?.[1] ?? ''
-        );
-
         document.addEventListener('DOMContentLoaded', () => {
             const list = document.getElementById('tools-list');
             if (!list) return;
 
             // Quarto/Pandoc wraps each heading + content in <section class="levelN" id="...">
-            const SKIP = new Set(['level2', 'level3', 'anchored', 'unnumbered', 'unlisted', 'header-section-number']);
-            const toolSections = [...list.querySelectorAll('section.level2')];
+            const SKIP = new Set(['level3', 'level4', 'anchored', 'unnumbered', 'unlisted', 'header-section-number']);
+            const toolSections = [...list.querySelectorAll('section.level3')];
             if (!toolSections.length) return;
 
             const sections = toolSections.map(sec => ({
                 sec,
-                heading: sec.querySelector('h2'),
                 cats: [...sec.classList].filter(c => !SKIP.has(c)),
             }));
 
@@ -96,75 +74,6 @@ include-in-header:
                 filterBar.appendChild(makeBtn(label, cat));
             });
             list.before(filterBar);
-
-            // Make sections collapsible
-            const sectionEls = sections.map(({ sec, heading, cats }) => {
-                sec.classList.add('tool-section');
-                sec.dataset.cats = cats.join(' ');
-                sec.dataset.open = 'false';
-
-                const headerDiv = document.createElement('div');
-                headerDiv.className = 'tool-header';
-                headerDiv.setAttribute('role', 'button');
-                headerDiv.setAttribute('tabindex', '0');
-
-                const toggleSpan = document.createElement('span');
-                toggleSpan.className = 'tool-toggle';
-                toggleSpan.setAttribute('aria-hidden', 'true');
-                toggleSpan.textContent = '▶';
-
-                // Wrap h2 in headerDiv; move all remaining children into bodyDiv
-                sec.insertBefore(headerDiv, heading);
-                heading.prepend(toggleSpan);
-                headerDiv.appendChild(heading);
-
-                const bodyDiv = document.createElement('div');
-                bodyDiv.className = 'tool-body';
-                bodyDiv.style.display = 'none';
-                while (sec.children.length > 1) {
-                    bodyDiv.appendChild(sec.children[1]);
-                }
-                sec.appendChild(bodyDiv);
-
-                const open = (scroll = false) => {
-                    bodyDiv.style.display = '';
-                    sec.dataset.open = 'true';
-                    if (scroll) setTimeout(() => heading.scrollIntoView({ behavior: 'smooth', block: 'start' }), 50);
-                };
-                const close = () => {
-                    bodyDiv.style.display = 'none';
-                    sec.dataset.open = 'false';
-                };
-                const handleToggle = () => sec.dataset.open === 'true' ? close() : open();
-
-                headerDiv.addEventListener('click', (e) => {
-                    if (e.target.closest('a')) return;
-                    handleToggle();
-                });
-                headerDiv.addEventListener('keydown', e => {
-                    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleToggle(); }
-                });
-
-                return { sec, heading, open, close };
-            });
-
-            // Open based on URL hash (Quarto puts the id on the <section>, not the <h2>)
-            const getHash = () => window.location.hash.split('#:~:')[0].slice(1);
-            const openByHash = (hash) => {
-                if (!hash) return;
-                const match = sectionEls.find(s => s.sec.id === hash);
-                if (match) match.open(true);
-            };
-            openByHash(getHash());
-            window.addEventListener('hashchange', () => openByHash(getHash()));
-
-            // Open based on Quarto search query or Google text fragment
-            const query = (__searchQuery || __textFragment || '').toLowerCase();
-            if (query) {
-                sectionEls.forEach(({ sec, open }) => {
-                    if (sec.textContent.toLowerCase().includes(query)) open();
-                });
-            }
         });
         </script>
 ---
@@ -172,112 +81,6 @@ include-in-header:
 The Vrije Universiteit Amsterdam hosts a wide range of research data management (RDM) tools designed to support researchers throughout their entire project lifecycle.
 
 Whether you are starting your data management plan, collecting data, or looking for long-term storage solutions, RDM tools help you optimise your research process and make data handling efficient.
-
-::: {#tools-list}
-
-## ADA {#ada .computing}
-
-[ADA](/tools/ada/index.qmd) is VU's on-campus computing cluster for multi-node computations. ADA is beneficial when your research requires more computational power than a standard laptop or workstation. It offers access to multi-core CPUs, large-memory nodes, and batch GPU capacity for efficient large-scale data processing and analysis. Account needs to be requested via the VU Service Portal.
-
-## Amberscript {#amberscript .transcription}
-
-[Amberscript](../topics/transcription.qmd) offers both automated transcription and human-edited transcription. Human-edited transcriptions can be done verbatim or literal. This is a paid service available to VU researchers.
-
-## ATLAS.ti {#atlasti .data-analysis}
-
-[ATLAS.ti](https://atlasti.com/) is qualitative data analysis software that supports coding, text interpretation, and multimedia analysis. Instructions for using the VU ATLAS.ti licence are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&table=kb_knowledge&sys_id=e8a8a1f4874bc15010be65b40cbb351c). ATLAS.ti also provides [video tutorials](https://atlasti.com/video-tutorials) to help users get started.
-
-## DataverseNL {#dataversenl .data-archiving .data-publishing}
-
-[DataverseNL](/tools/dataversenl/index.qmd) is an open access data repository hosted by DANS for archiving and publishing research datasets. DataverseNL is not suitable for data files containing personal or confidential data. For archiving and publishing sensitive data, researchers should use [Yoda](#yoda).
-
-## DMPonline {#dmponline .data-management-plan}
-
-[DMPonline](/tools/dmponline/index.qmd) is an online platform that enables researchers to create, manage, and share Data Management Plans. The platform provides structured templates to help researchers address key aspects of the research lifecycle, including legal and ethical requirements, storage, preservation, documentation, and responsibilities. Log in using VU credentials with Single Sign-on (SSO).
-
-## GitLab {#gitlab .code-development}
-
-[GitLab](https://gitlab.vu.nl) is VU's code repository for research use. Features include version control and the possibility to collaborate on code. Maintained by the University Library. There is also a [GitLab server for general use](https://git.vu.nl).
-
-## iThenticate {#ithenticate .plagiarism-detection}
-
-[iThenticate](/tools/ithenticate/index.qmd) is plagiarism detection software offered by Turnitin that compares a researcher's work with published academic sources and bibliographic databases such as Crossref. At VU Amsterdam, plagiarism checks are used primarily in an educational and preventative way, with the aim of raising awareness of scientific integrity.
-
-## MATLAB {#matlab .data-analysis}
-
-[MATLAB](https://www.mathworks.com/academia/tah-portal/vrije-universiteit-amsterdam-30688271.html) is a programming language for numerical analysis, data visualisation, and algorithm development. Instructions for using the VU MATLAB licence are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0011916&table=kb_knowledge&searchTerm=matlab).
-
-## Nebula {#nebula .computing}
-
-[Nebula](/tools/nebula/index.qmd) is developed to support researchers who want to use AI models in their work. It provides researchers across all departments with safe and seamless access to open-source large language models (LLMs). Nebula is fully hosted on VU premises, ensuring that no data leaves the campus.
-
-## OSF {#osf .data-publishing .preregistration}
-
-[OSF](/tools/osf/index.qmd) is a cloud-based, open-source tool that supports researchers throughout the **active research stage**. It facilitates collaboration and connects services, materials, and other research objects for private use or public sharing. OSF also supports preregistration of research.
-
-## Pure {#pure .research-output-registration}
-
-[Pure](/tools/pure/index.qmd) is the Current Research Information System (CRIS) used at VU, serving as the central platform for registering and managing all research activities and outputs, including publications, datasets, research software/code, and projects. All researchers at VU Amsterdam have access to the back end and a public profile page.
-
-## Qualtrics {#qualtrics .online-survey}
-
-[Qualtrics](/tools/qualtrics/index.qmd) is a cloud-based survey platform that enables users to create and manage online surveys. It supports a variety of complex survey design requirements. VU's Qualtrics licence is intended for scientific research purposes only. Log in using VU credentials with Single Sign-on (SSO).
-
-## Research Cloud {#research-cloud .computing .virtual-research-environment}
-
-[Research Cloud](/tools/researchcloud/index.qmd) is a SURF-hosted portal that allows you to easily build or reuse a virtual research environment. It enables you to run one or more servers with applications that are accessible over the internet. Requires SRAM collaboration credentials and computing credits.
-
-## Research Drive {#research-drive .data-storage}
-
-[Research Drive](/tools/researchdrive/index.qmd) is a SURF-hosted online storage and collaboration platform for research data. It allows researchers to easily store and share files with others, both within and outside VU Amsterdam. Data must be downloaded via Nextcloud to a local device for analysis. Fine-grained folder access rights are possible. Account needs to be requested via the VU Service Portal.
-
-## SciCloud {#scicloud .computing .virtual-research-environment}
-
-[SciCloud](/tools/scicloud/index.qmd) is offered by IT for Research (ITvO) and is based on the open-source middleware OpenNebula (ONE). It allows researchers to purchase server capacity to support their research applications. Good for web applications and 24/7 services.
-
-## SciStor {#scistor .data-storage .file-transfer}
-
-[SciStor](/tools/scistor/index.qmd) is an IT-hosted data storage service designed for storing large volumes of research data on campus. It provides high-speed connections to lab equipment, laptops, and workstations, and can connect to high-performance computers. Storage space needs to be requested via the VU Service Portal.
-
-## SciSure {#scisure .lab-journal}
-
-[SciSure](/tools/scisure/index.qmd) is an application that supports researchers in documenting experiments and results in a digital lab journal. It can be used to track results and share data recorded during experiments within an electronic lab notebook.
-
-## Snellius {#snellius .computing}
-
-[Snellius](/tools/snellius/index.qmd) is a National Supercomputer hosted by SURF, designed for large-scale experiments such as simulations and modelling that require significant computing power. Access can be requested through the VU contract with SURF or through an NWO compute grant.
-
-## SPSS {#spss .data-analysis}
-
-[SPSS](https://www.surfspot.nl/vu) is a statistical analysis software package used for data management, statistical analysis, and data visualisation. Instructions for using the VU SPSS licence are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0022399&table=kb_knowledge&searchTerm=spss). Free tutorials are available from [how2stats](https://how2stats.net/); more in-depth paid tutorials from [Laerd Statistics](https://statistics.laerd.com/).
-
-## Stata {#stata .data-analysis}
-
-[Stata](https://www.scienceplus.com/nl/statistiek/stata/) is a statistical package used for quantitative data analysis. Stata is only available for specific user groups — if you are unsure whether Stata is available to you, ask your supervisor or head of research group. More information and tutorials can be found in the [VU LibGuide 'Working with data'](https://libguides.vu.nl/working-with-data/software/stata-sources).
-
-## SURFfilesender {#surffilesender .file-transfer}
-
-[SURFfilesender](https://filesender.surf.nl/?s=home) is a web-based application that allows authenticated users to securely send arbitrarily large files to other users. Users without an account can be sent a guest upload voucher by an authenticated user. Log in using VU credentials with Single Sign-on (SSO).
-
-## Transcript Online {#transcript-online .transcription}
-
-[Transcript Online](../topics/transcription.qmd) offers human-edited transcription. Experienced transcribers convert speech in audio or video files into both verbatim and literal transcriptions. This is a paid service available to VU researchers.
-
-## VU Compute Hub {#vu-compute-hub .computing}
-
-[VU Compute Hub](/tools/vucomputehub/index.qmd) is a JupyterHub service hosted by IT primarily intended for educational use, but also available to VU researchers who need a low-threshold environment for running analyses.
-
-## Yoda {#yoda .data-archiving .data-publishing .data-storage}
-
-[Yoda](/tools/yoda/index.qmd) is a data storage platform and repository hosted by SURF. It supports researchers throughout the entire research lifecycle, from safe storage and sharing during the research process, to sharing within research collaborations, and ultimately to data archiving and publication. Account needs to be requested via the VU Service Portal.
-
-## Zivver {#zivver .file-transfer}
-
-[Zivver](https://www.zivver.com/products/email-encryption-software) offers a secure way to send encrypted emails and file attachments up to 5TB. This is available to all VU employees. Instructions for using Zivver are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0012157).
-
-:::
-
-
 
 ## Choosing a Tool
 
@@ -304,3 +107,112 @@ The image below lists all services and tools provided by the Network Research Da
 ## Tool Not Listed?
 
 If you need a research tool that isn't provided by VU Amsterdam, you can contact the RDM Support Desk at [rdm@vu.nl](mailto:rdm@vu.nl) to discuss your requirements. We can suggest an alternative or forward your question to IT or the procurement team.
+
+
+## Tool list
+Click on a category to filter the list.
+
+::: {#tools-list}
+
+### ADA {#ada .computing}
+
+[ADA](/tools/ada/index.qmd) is VU's on-campus computing cluster for multi-node computations. ADA is beneficial when your research requires more computational power than a standard laptop or workstation. It offers access to multi-core CPUs, large-memory nodes, and batch GPU capacity for efficient large-scale data processing and analysis. Account needs to be requested via the VU Service Portal.
+
+### Amberscript {#amberscript .transcription}
+
+[Amberscript](../topics/transcription.qmd) offers both automated transcription and human-edited transcription. Human-edited transcriptions can be done verbatim or literal. This is a paid service available to VU researchers.
+
+### ATLAS.ti {#atlasti .data-analysis}
+
+[ATLAS.ti](https://atlasti.com/) is qualitative data analysis software that supports coding, text interpretation, and multimedia analysis. Instructions for using the VU ATLAS.ti licence are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&table=kb_knowledge&sys_id=e8a8a1f4874bc15010be65b40cbb351c). ATLAS.ti also provides [video tutorials](https://atlasti.com/video-tutorials) to help users get started.
+
+### DataverseNL {#dataversenl .data-archiving .data-publishing}
+
+[DataverseNL](/tools/dataversenl/index.qmd) is an open access data repository hosted by DANS for archiving and publishing research datasets. DataverseNL is not suitable for data files containing personal or confidential data. For archiving and publishing sensitive data, researchers should use [Yoda](#yoda).
+
+### DMPonline {#dmponline .data-management-plan}
+
+[DMPonline](/tools/dmponline/index.qmd) is an online platform that enables researchers to create, manage, and share Data Management Plans. The platform provides structured templates to help researchers address key aspects of the research lifecycle, including legal and ethical requirements, storage, preservation, documentation, and responsibilities. Log in using VU credentials with Single Sign-on (SSO).
+
+### GitLab {#gitlab .code-development}
+
+[GitLab](https://gitlab.vu.nl) is VU's code repository for research use. Features include version control and the possibility to collaborate on code. Maintained by the University Library. There is also a [GitLab server for general use](https://git.vu.nl).
+
+### iThenticate {#ithenticate .plagiarism-detection}
+
+[iThenticate](/tools/ithenticate/index.qmd) is plagiarism detection software offered by Turnitin that compares a researcher's work with published academic sources and bibliographic databases such as Crossref. At VU Amsterdam, plagiarism checks are used primarily in an educational and preventative way, with the aim of raising awareness of scientific integrity.
+
+### MATLAB {#matlab .data-analysis}
+
+[MATLAB](https://www.mathworks.com/academia/tah-portal/vrije-universiteit-amsterdam-30688271.html) is a programming language for numerical analysis, data visualisation, and algorithm development. Instructions for using the VU MATLAB licence are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0011916&table=kb_knowledge&searchTerm=matlab).
+
+### Nebula {#nebula .computing}
+
+[Nebula](/tools/nebula/index.qmd) is developed to support researchers who want to use AI models in their work. It provides researchers across all departments with safe and seamless access to open-source large language models (LLMs). Nebula is fully hosted on VU premises, ensuring that no data leaves the campus.
+
+### OSF {#osf .data-publishing .preregistration}
+
+[OSF](/tools/osf/index.qmd) is a cloud-based, open-source tool that supports researchers throughout the **active research stage**. It facilitates collaboration and connects services, materials, and other research objects for private use or public sharing. OSF also supports preregistration of research.
+
+### Pure {#pure .research-output-registration}
+
+[Pure](/tools/pure/index.qmd) is the Current Research Information System (CRIS) used at VU, serving as the central platform for registering and managing all research activities and outputs, including publications, datasets, research software/code, and projects. All researchers at VU Amsterdam have access to the back end and a public profile page.
+
+### Qualtrics {#qualtrics .online-survey}
+
+[Qualtrics](/tools/qualtrics/index.qmd) is a cloud-based survey platform that enables users to create and manage online surveys. It supports a variety of complex survey design requirements. VU's Qualtrics licence is intended for scientific research purposes only. Log in using VU credentials with Single Sign-on (SSO).
+
+### Research Cloud {#research-cloud .computing .virtual-research-environment}
+
+[Research Cloud](/tools/researchcloud/index.qmd) is a SURF-hosted portal that allows you to easily build or reuse a virtual research environment. It enables you to run one or more servers with applications that are accessible over the internet. Requires SRAM collaboration credentials and computing credits.
+
+### Research Drive {#research-drive .data-storage}
+
+[Research Drive](/tools/researchdrive/index.qmd) is a SURF-hosted online storage and collaboration platform for research data. It allows researchers to easily store and share files with others, both within and outside VU Amsterdam. Data must be downloaded via Nextcloud to a local device for analysis. Fine-grained folder access rights are possible. Account needs to be requested via the VU Service Portal.
+
+### SciCloud {#scicloud .computing .virtual-research-environment}
+
+[SciCloud](/tools/scicloud/index.qmd) is offered by IT for Research (ITvO) and is based on the open-source middleware OpenNebula (ONE). It allows researchers to purchase server capacity to support their research applications. Good for web applications and 24/7 services.
+
+### SciStor {#scistor .data-storage .file-transfer}
+
+[SciStor](/tools/scistor/index.qmd) is an IT-hosted data storage service designed for storing large volumes of research data on campus. It provides high-speed connections to lab equipment, laptops, and workstations, and can connect to high-performance computers. Storage space needs to be requested via the VU Service Portal.
+
+### SciSure {#scisure .lab-journal}
+
+[SciSure](/tools/scisure/index.qmd) is an application that supports researchers in documenting experiments and results in a digital lab journal. It can be used to track results and share data recorded during experiments within an electronic lab notebook.
+
+### Snellius {#snellius .computing}
+
+[Snellius](/tools/snellius/index.qmd) is a National Supercomputer hosted by SURF, designed for large-scale experiments such as simulations and modelling that require significant computing power. Access can be requested through the VU contract with SURF or through an NWO compute grant.
+
+### SPSS {#spss .data-analysis}
+
+[SPSS](https://www.surfspot.nl/vu) is a statistical analysis software package used for data management, statistical analysis, and data visualisation. Instructions for using the VU SPSS licence are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0022399&table=kb_knowledge&searchTerm=spss). Free tutorials are available from [how2stats](https://how2stats.net/); more in-depth paid tutorials from [Laerd Statistics](https://statistics.laerd.com/).
+
+### Stata {#stata .data-analysis}
+
+[Stata](https://www.scienceplus.com/nl/statistiek/stata/) is a statistical package used for quantitative data analysis. Stata is only available for specific user groups — if you are unsure whether Stata is available to you, ask your supervisor or head of research group. More information and tutorials can be found in the [VU LibGuide 'Working with data'](https://libguides.vu.nl/working-with-data/software/stata-sources).
+
+### SURFfilesender {#surffilesender .file-transfer}
+
+[SURFfilesender](https://filesender.surf.nl/?s=home) is a web-based application that allows authenticated users to securely send arbitrarily large files to other users. Users without an account can be sent a guest upload voucher by an authenticated user. Log in using VU credentials with Single Sign-on (SSO).
+
+### Transcript Online {#transcript-online .transcription}
+
+[Transcript Online](../topics/transcription.qmd) offers human-edited transcription. Experienced transcribers convert speech in audio or video files into both verbatim and literal transcriptions. This is a paid service available to VU researchers.
+
+### VU Compute Hub {#vu-compute-hub .computing}
+
+[VU Compute Hub](/tools/vucomputehub/index.qmd) is a JupyterHub service hosted by IT primarily intended for educational use, but also available to VU researchers who need a low-threshold environment for running analyses.
+
+### Yoda {#yoda .data-archiving .data-publishing .data-storage}
+
+[Yoda](/tools/yoda/index.qmd) is a data storage platform and repository hosted by SURF. It supports researchers throughout the entire research lifecycle, from safe storage and sharing during the research process, to sharing within research collaborations, and ultimately to data archiving and publication. Account needs to be requested via the VU Service Portal.
+
+### Zivver {#zivver .file-transfer}
+
+[Zivver](https://www.zivver.com/products/email-encryption-software) offers a secure way to send encrypted emails and file attachments up to 5TB. This is available to all VU employees. Instructions for using Zivver are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0012157).
+
+:::
+

--- a/topics/rdm-tools.qmd
+++ b/topics/rdm-tools.qmd
@@ -87,7 +87,7 @@ Which tool is most suitable for your research can vary, depending on what kind o
 
 Specifically for data storage tools, the [Data Storage Finder](https://vu.nl/en/research/storagefinder) can help you decide which storage platforms fit your situation best.
 
-## Tool Not Listed?
+### Tool Not Listed?
 
 If you need a research tool that isn't provided by VU Amsterdam, you can contact the RDM Support Desk at [rdm@vu.nl](mailto:rdm@vu.nl) to discuss your requirements. We can suggest an alternative or forward your question to IT or the procurement team.
 
@@ -108,6 +108,10 @@ Click on a category to filter the list.
 
 [ATLAS.ti](https://atlasti.com/) is qualitative data analysis software that supports coding, text interpretation, and multimedia analysis. Instructions for using the VU ATLAS.ti licence are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&table=kb_knowledge&sys_id=e8a8a1f4874bc15010be65b40cbb351c). ATLAS.ti also provides [video tutorials](https://atlasti.com/video-tutorials) to help users get started.
 
+## Bitwarden {#bitwarden .data-security}
+
+[Bitwarden](https://vault.bitwarden.eu/#/signup) is a password manager provided by VU Amsterdam. With Bitwarden Password Manager, you can generate strong, unique passwords for every account you use online. The tool can create, save, and autofill passwords. Instructions for using the VU Bitwarden licence are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0022553&table=kb_knowledge&searchTerm=bitwarden). Bitwarden also provides [documentation](https://bitwarden.com/help/getting-started-webvault/) to help users get started.
+
 ## DataverseNL {#dataversenl .data-archiving .data-publishing}
 
 [DataverseNL](/tools/dataversenl/index.qmd) is an open access data repository hosted by DANS for archiving and publishing research datasets. DataverseNL is not suitable for data files containing personal or confidential data. For archiving and publishing sensitive data, researchers should use [Yoda](#yoda).
@@ -115,6 +119,10 @@ Click on a category to filter the list.
 ## DMPonline {#dmponline .data-management-plan}
 
 [DMPonline](/tools/dmponline/index.qmd) is an online platform that enables researchers to create, manage, and share Data Management Plans. The platform provides structured templates to help researchers address key aspects of the research lifecycle, including legal and ethical requirements, storage, preservation, documentation, and responsibilities. Log in using VU credentials with Single Sign-on (SSO).
+
+## eduVPN {#eduvpn .data-security}
+
+[eduVPN](https://www.surf.nl/diensten/beveiliging/eduvpn) is an app that allows you to safely access the internet anywhere and access restricted VU services. This allows you to work safely on public Wi-Fi networks and access systems that are only available from campus. eduVPN offers two different options for connecting securely. Secure Internet protects your internet connection on public or unsecured Wi-Fi networks, ensuring that your data and privacy remain protected. Institute Access gives you secure access to a number of restricted VU services as if you were physically present on campus. This second option is only available for staff with a valid VUnetID and only works on laptops issued and managed by VU Amsterdam. Instructions for using eduVPN are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0022732&table=kb_knowledge&searchTerm=eduvpn). If you want to access SciStor, SciCloud and ADA from outside campus, you need eduVPN.
 
 ## GitLab {#gitlab .code-development}
 
@@ -192,7 +200,7 @@ Click on a category to filter the list.
 
 [Yoda](/tools/yoda/index.qmd) is a data storage platform and repository hosted by SURF. It supports researchers throughout the entire research lifecycle, from safe storage and sharing during the research process, to sharing within research collaborations, and ultimately to data archiving and publication. Account needs to be requested via the VU Service Portal.
 
-## Zivver {#zivver .file-transfer}
+## Zivver {#zivver .file-transfer .data-security}
 
 [Zivver](https://www.zivver.com/products/email-encryption-software) offers a secure way to send encrypted emails and file attachments up to 5TB. This is available to all VU employees. Instructions for using Zivver are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0012157).
 

--- a/topics/rdm-tools.qmd
+++ b/topics/rdm-tools.qmd
@@ -1,6 +1,30 @@
 ---
 title: RDM Tools
 categories: [Knowledge Items]
+include-in-header: 
+    - text: |
+        <script>
+        const params = new URLSearchParams(window.location.search);
+        const query = params.get('q');
+        window.addEventListener('DOMContentLoaded', () => {
+            if (!query) return;
+
+            const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+            const queryLower = query.toLowerCase();
+
+            let node;
+
+            while ((node = walker.nextNode())) {
+                if (node.nodeValue.toLowerCase().includes(queryLower)) {
+                let el = node.parentElement;
+                while (el) {
+                    if (el.tagName === 'DETAILS') el.open = true;
+                    el = el.parentElement;
+                }
+                }
+            }
+        });
+        </script>
 ---
 
 The Vrije Universiteit Amsterdam hosts a wide range of research data management (RDM) tools designed for researchers to support researchers throughout their enitre project lifecycle. 
@@ -31,7 +55,7 @@ There are several tools available to support researchers in performing computati
 
 - [Research Cloud](/tools/researchcloud/index.qmd) is a SURF-hosted portal that allows you to easily build or reuse a virtual research environment. It enables you to run one or more servers with applications that are accessible over the internet. Requires SRAM collaboration credentials and computing credits.
 
-- [SciCloud](/tools/scicloud/index.qmd) is offered by IT for Research ([ITvO](topics/itvo.qmd)) and is based on the open-source middleware OpenNebula (ONE). It allows researchers to purchase server capacity to support their research applications. Good for web applications and 24/7 services.
+- [SciCloud](/tools/scicloud/index.qmd) is offered by IT for Research ([ITvO](/topics/itvo.qmd)) and is based on the open-source middleware OpenNebula (ONE). It allows researchers to purchase server capacity to support their research applications. Good for web applications and 24/7 services.
 
 - [Snellius](/tools/snellius/index.qmd) is a National Supercomputer hosted by SURF, designed for large-scale experiments, such as simulations and modelling, that require significant computing power. Access can be requested through the VU contract with SURF or through an NWO compute grant.
 

--- a/topics/rdm-tools.qmd
+++ b/topics/rdm-tools.qmd
@@ -97,103 +97,103 @@ Click on a category to filter the list.
 
 ::: {#tools-list}
 
-### ADA {#ada .computing}
+## ADA {#ada .computing}
 
 [ADA](/tools/ada/index.qmd) is VU's on-campus computing cluster for multi-node computations. ADA is beneficial when your research requires more computational power than a standard laptop or workstation. It offers access to multi-core CPUs, large-memory nodes, and batch GPU capacity for efficient large-scale data processing and analysis. Account needs to be requested via the VU Service Portal.
 
-### Amberscript {#amberscript .transcription}
+## Amberscript {#amberscript .transcription}
 
 [Amberscript](../topics/transcription.qmd) offers both automated transcription and human-edited transcription. Human-edited transcriptions can be done verbatim or literal. This is a paid service available to VU researchers.
 
-### ATLAS.ti {#atlasti .data-analysis}
+## ATLAS.ti {#atlasti .data-analysis}
 
 [ATLAS.ti](https://atlasti.com/) is qualitative data analysis software that supports coding, text interpretation, and multimedia analysis. Instructions for using the VU ATLAS.ti licence are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&table=kb_knowledge&sys_id=e8a8a1f4874bc15010be65b40cbb351c). ATLAS.ti also provides [video tutorials](https://atlasti.com/video-tutorials) to help users get started.
 
-### DataverseNL {#dataversenl .data-archiving .data-publishing}
+## DataverseNL {#dataversenl .data-archiving .data-publishing}
 
 [DataverseNL](/tools/dataversenl/index.qmd) is an open access data repository hosted by DANS for archiving and publishing research datasets. DataverseNL is not suitable for data files containing personal or confidential data. For archiving and publishing sensitive data, researchers should use [Yoda](#yoda).
 
-### DMPonline {#dmponline .data-management-plan}
+## DMPonline {#dmponline .data-management-plan}
 
 [DMPonline](/tools/dmponline/index.qmd) is an online platform that enables researchers to create, manage, and share Data Management Plans. The platform provides structured templates to help researchers address key aspects of the research lifecycle, including legal and ethical requirements, storage, preservation, documentation, and responsibilities. Log in using VU credentials with Single Sign-on (SSO).
 
-### GitLab {#gitlab .code-development}
+## GitLab {#gitlab .code-development}
 
 [GitLab](https://gitlab.vu.nl) is VU's code repository for research use. Features include version control and the possibility to collaborate on code. Maintained by the University Library. There is also a [GitLab server for general use](https://git.vu.nl).
 
-### iThenticate {#ithenticate .plagiarism-detection}
+## iThenticate {#ithenticate .plagiarism-detection}
 
 [iThenticate](/tools/ithenticate/index.qmd) is plagiarism detection software offered by Turnitin that compares a researcher's work with published academic sources and bibliographic databases such as Crossref. At VU Amsterdam, plagiarism checks are used primarily in an educational and preventative way, with the aim of raising awareness of scientific integrity.
 
-### MATLAB {#matlab .data-analysis}
+## MATLAB {#matlab .data-analysis}
 
 [MATLAB](https://www.mathworks.com/academia/tah-portal/vrije-universiteit-amsterdam-30688271.html) is a programming language for numerical analysis, data visualisation, and algorithm development. Instructions for using the VU MATLAB licence are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0011916&table=kb_knowledge&searchTerm=matlab).
 
-### Nebula {#nebula .computing}
+## Nebula {#nebula .computing}
 
 [Nebula](/tools/nebula/index.qmd) is developed to support researchers who want to use AI models in their work. It provides researchers across all departments with safe and seamless access to open-source large language models (LLMs). Nebula is fully hosted on VU premises, ensuring that no data leaves the campus.
 
-### OSF {#osf .data-publishing .preregistration}
+## OSF {#osf .data-publishing .preregistration}
 
 [OSF](/tools/osf/index.qmd) is a cloud-based, open-source tool that supports researchers throughout the **active research stage**. It facilitates collaboration and connects services, materials, and other research objects for private use or public sharing. OSF also supports preregistration of research.
 
-### Pure {#pure .research-output-registration}
+## Pure {#pure .research-output-registration}
 
 [Pure](/tools/pure/index.qmd) is the Current Research Information System (CRIS) used at VU, serving as the central platform for registering and managing all research activities and outputs, including publications, datasets, research software/code, and projects. All researchers at VU Amsterdam have access to the back end and a public profile page.
 
-### Qualtrics {#qualtrics .online-survey}
+## Qualtrics {#qualtrics .online-survey}
 
 [Qualtrics](/tools/qualtrics/index.qmd) is a cloud-based survey platform that enables users to create and manage online surveys. It supports a variety of complex survey design requirements. VU's Qualtrics licence is intended for scientific research purposes only. Log in using VU credentials with Single Sign-on (SSO).
 
-### Research Cloud {#research-cloud .computing .virtual-research-environment}
+## Research Cloud {#research-cloud .computing .virtual-research-environment}
 
 [Research Cloud](/tools/researchcloud/index.qmd) is a SURF-hosted portal that allows you to easily build or reuse a virtual research environment. It enables you to run one or more servers with applications that are accessible over the internet. Requires SRAM collaboration credentials and computing credits.
 
-### Research Drive {#research-drive .data-storage}
+## Research Drive {#research-drive .data-storage}
 
 [Research Drive](/tools/researchdrive/index.qmd) is a SURF-hosted online storage and collaboration platform for research data. It allows researchers to easily store and share files with others, both within and outside VU Amsterdam. Data must be downloaded via Nextcloud to a local device for analysis. Fine-grained folder access rights are possible. Account needs to be requested via the VU Service Portal.
 
-### SciCloud {#scicloud .computing .virtual-research-environment}
+## SciCloud {#scicloud .computing .virtual-research-environment}
 
 [SciCloud](/tools/scicloud/index.qmd) is offered by IT for Research (ITvO) and is based on the open-source middleware OpenNebula (ONE). It allows researchers to purchase server capacity to support their research applications. Good for web applications and 24/7 services.
 
-### SciStor {#scistor .data-storage}
+## SciStor {#scistor .data-storage}
 
 [SciStor](/tools/scistor/index.qmd) is an IT-hosted data storage service designed for storing large volumes of research data on campus. It provides high-speed connections to lab equipment, laptops, and workstations, and can connect to high-performance computers. Storage space needs to be requested via the VU Service Portal.
 
-### SciSure {#scisure .lab-journal}
+## SciSure {#scisure .lab-journal}
 
 [SciSure](/tools/scisure/index.qmd) is an application that supports researchers in documenting experiments and results in a digital lab journal. It can be used to track results and share data recorded during experiments within an electronic lab notebook.
 
-### Snellius {#snellius .computing}
+## Snellius {#snellius .computing}
 
 [Snellius](/tools/snellius/index.qmd) is a National Supercomputer hosted by SURF, designed for large-scale experiments such as simulations and modelling that require significant computing power. Access can be requested through the VU contract with SURF or through an NWO compute grant.
 
-### SPSS {#spss .data-analysis}
+## SPSS {#spss .data-analysis}
 
 [SPSS](https://www.surfspot.nl/vu) is a statistical analysis software package used for data management, statistical analysis, and data visualisation. Instructions for using the VU SPSS licence are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0022399&table=kb_knowledge&searchTerm=spss). Free tutorials are available from [how2stats](https://how2stats.net/); more in-depth paid tutorials from [Laerd Statistics](https://statistics.laerd.com/).
 
-### Stata {#stata .data-analysis}
+## Stata {#stata .data-analysis}
 
 [Stata](https://www.scienceplus.com/nl/statistiek/stata/) is a statistical package used for quantitative data analysis. Stata is only available for specific user groups — if you are unsure whether Stata is available to you, ask your supervisor or head of research group. More information and tutorials can be found in the [VU LibGuide 'Working with data'](https://libguides.vu.nl/working-with-data/software/stata-sources).
 
-### SURFfilesender {#surffilesender .file-transfer}
+## SURFfilesender {#surffilesender .file-transfer}
 
 [SURFfilesender](https://filesender.surf.nl/?s=home) is a web-based application that allows authenticated users to securely send arbitrarily large files to other users. Users without an account can be sent a guest upload voucher by an authenticated user. Log in using VU credentials with Single Sign-on (SSO).
 
-### Transcript Online {#transcript-online .transcription}
+## Transcript Online {#transcript-online .transcription}
 
 [Transcript Online](../topics/transcription.qmd) offers human-edited transcription. Experienced transcribers convert speech in audio or video files into both verbatim and literal transcriptions. This is a paid service available to VU researchers.
 
-### VU Compute Hub {#vu-compute-hub .computing}
+## VU Compute Hub {#vu-compute-hub .computing}
 
 [VU Compute Hub](/tools/vucomputehub/index.qmd) is a JupyterHub service hosted by IT primarily intended for educational use, but also available to VU researchers who need a low-threshold environment for running analyses.
 
-### Yoda {#yoda .data-archiving .data-publishing .data-storage}
+## Yoda {#yoda .data-archiving .data-publishing .data-storage}
 
 [Yoda](/tools/yoda/index.qmd) is a data storage platform and repository hosted by SURF. It supports researchers throughout the entire research lifecycle, from safe storage and sharing during the research process, to sharing within research collaborations, and ultimately to data archiving and publication. Account needs to be requested via the VU Service Portal.
 
-### Zivver {#zivver .file-transfer}
+## Zivver {#zivver .file-transfer}
 
 [Zivver](https://www.zivver.com/products/email-encryption-software) offers a secure way to send encrypted emails and file attachments up to 5TB. This is available to all VU employees. Instructions for using Zivver are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0012157).
 

--- a/topics/rdm-tools.qmd
+++ b/topics/rdm-tools.qmd
@@ -34,8 +34,8 @@ include-in-header:
             if (!list) return;
 
             // Quarto/Pandoc wraps each heading + content in <section class="levelN" id="...">
-            const SKIP = new Set(['level3', 'level4', 'anchored', 'unnumbered', 'unlisted', 'header-section-number']);
-            const toolSections = [...list.querySelectorAll('section.level3')];
+            const SKIP = new Set(['level2', 'level4', 'anchored', 'unnumbered', 'unlisted', 'header-section-number']);
+            const toolSections = [...list.querySelectorAll('section.level2')];
             if (!toolSections.length) return;
 
             const sections = toolSections.map(sec => ({

--- a/topics/rdm-tools.qmd
+++ b/topics/rdm-tools.qmd
@@ -78,9 +78,7 @@ include-in-header:
         </script>
 ---
 
-The Vrije Universiteit Amsterdam hosts a wide range of research data management (RDM) tools designed to support researchers throughout their entire project lifecycle.
-
-Whether you are starting your data management plan, collecting data, or looking for long-term storage solutions, RDM tools help you optimise your research process and make data handling efficient.
+The Vrije Universiteit Amsterdam offers a wide range of Research Data Management (RDM) tools designed to support researchers throughout their entire project lifecycle.
 
 ## Choosing a Tool
 
@@ -90,24 +88,9 @@ Which tool is most suitable for your research can vary, depending on what kind o
 
 Specifically for data storage tools, the [Data Storage Finder](https://vu.nl/en/research/storagefinder) can help you decide which storage platforms fit your situation best.
 
-### Overviews
-
-A subset of the tools listed above is highlighted in the video below ([DMPonline](/tools/dmponline/index.qmd), [DataverseNL](/tools/dataversenl/index.qmd), [Yoda](/tools/yoda/index.qmd), [OSF](/tools/osf/index.qmd), [Research Drive](/tools/researchdrive/index.qmd), [SciStor](/tools/scistor/index.qmd)). This is a nice resource if you'd like a quick, visual overview of these tools.
-
-<!-- markdownlint-disable MD033 -->
-<div style="position: relative; width: 100%; height: 0; padding-bottom: 56.25%">
-<iframe src="https://vu.cloud.panopto.eu/Panopto/Pages/Embed.aspx?id=8357c8b8-3983-422d-a48e-b3a900b38cf1&autoplay=false&offerviewer=true&showtitle=true&showbrand=true&captions=false&interactivity=all" style="border: 1px solid #464646; position: absolute; top: 0; left: 0; width: 100%; height: 100%; box-sizing: border-box;" allowfullscreen allow="autoplay" aria-label="Panopto Embedded Video Player" aria-description="VU RDM - RDM tools V3 + subs"></iframe>
-</div>
-<!-- markdownlint-enable MD033 -->
-
-The image below lists all services and tools provided by the Network Research Data Support (NeRDS).
-
-![Overview of services and tools provided by the Network Research Data Support to researchers](../public/nerds-overview-services-tools.jpg)
-
 ## Tool Not Listed?
 
 If you need a research tool that isn't provided by VU Amsterdam, you can contact the RDM Support Desk at [rdm@vu.nl](mailto:rdm@vu.nl) to discuss your requirements. We can suggest an alternative or forward your question to IT or the procurement team.
-
 
 ## Tool list
 Click on a category to filter the list.

--- a/topics/rdm-tools.qmd
+++ b/topics/rdm-tools.qmd
@@ -1,7 +1,6 @@
 ---
 title: RDM Tools
 categories: [Knowledge Items]
-toc: false
 include-in-header:
     - text: |
         <style>

--- a/topics/rdm-tools.qmd
+++ b/topics/rdm-tools.qmd
@@ -1,220 +1,287 @@
 ---
 title: RDM Tools
 categories: [Knowledge Items]
-include-in-header: 
+toc: false
+include-in-header:
     - text: |
+        <style>
+        #tool-filter-bar {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.5rem;
+          margin-bottom: 1.5rem;
+          margin-top: 0.25rem;
+        }
+        .tool-filter-btn {
+          padding: 0.25rem 0.875rem;
+          border: 1px solid var(--bs-border-color, #dee2e6);
+          border-radius: 1rem;
+          background: none;
+          cursor: pointer;
+          font-size: 0.875rem;
+          color: inherit;
+        }
+        .tool-filter-btn:hover,
+        .tool-filter-btn.active {
+          background: var(--bs-primary, #0077b3);
+          color: #fff;
+          border-color: var(--bs-primary, #0077b3);
+        }
+        .tool-header { cursor: pointer; user-select: none; }
+        .tool-header:hover h2 { opacity: 0.8; }
+        .tool-toggle {
+          display: inline-block;
+          font-size: 0.6em;
+          color: var(--bs-secondary, #6c757d);
+          transition: transform 0.15s;
+          vertical-align: middle;
+          margin-right: 0.3em;
+        }
+        .tool-section[data-open="true"] .tool-toggle { transform: rotate(90deg); }
+        .tool-body {
+          padding-left: 1rem;
+          border-left: 3px solid var(--bs-border-color, #dee2e6);
+          margin-bottom: 1rem;
+        }
+        </style>
         <script>
-        const params = new URLSearchParams(window.location.search);
-        const query = params.get('q');
-        window.addEventListener('DOMContentLoaded', () => {
-            if (!query) return;
+        const __searchQuery = new URLSearchParams(window.location.search).get('q');
+        const __textFragment = decodeURIComponent(
+            window.location.hash.match(/#:~:text=([^&]*)/)?.[1] ?? ''
+        );
 
-            const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
-            const queryLower = query.toLowerCase();
+        document.addEventListener('DOMContentLoaded', () => {
+            const list = document.getElementById('tools-list');
+            if (!list) return;
 
-            let node;
+            // Quarto/Pandoc wraps each heading + content in <section class="levelN" id="...">
+            const SKIP = new Set(['level2', 'level3', 'anchored', 'unnumbered', 'unlisted', 'header-section-number']);
+            const toolSections = [...list.querySelectorAll('section.level2')];
+            if (!toolSections.length) return;
 
-            while ((node = walker.nextNode())) {
-                if (node.nodeValue.toLowerCase().includes(queryLower)) {
-                let el = node.parentElement;
-                while (el) {
-                    if (el.tagName === 'DETAILS') el.open = true;
-                    el = el.parentElement;
+            const sections = toolSections.map(sec => ({
+                sec,
+                heading: sec.querySelector('h2'),
+                cats: [...sec.classList].filter(c => !SKIP.has(c)),
+            }));
+
+            // Build category filter bar
+            const allCats = [...new Set(sections.flatMap(s => s.cats))].sort();
+            const filterBar = document.createElement('div');
+            filterBar.id = 'tool-filter-bar';
+            filterBar.setAttribute('role', 'group');
+            filterBar.setAttribute('aria-label', 'Filter by category');
+
+            const applyFilter = (cat) => {
+                [...filterBar.children].forEach(b =>
+                    b.classList.toggle('active', b.dataset.cat === cat)
+                );
+                sections.forEach(({ sec, cats }) => {
+                    sec.style.display = (!cat || cats.includes(cat)) ? '' : 'none';
+                });
+            };
+
+            const makeBtn = (label, cat) => {
+                const btn = document.createElement('button');
+                btn.className = 'tool-filter-btn' + (cat === '' ? ' active' : '');
+                btn.textContent = label;
+                btn.dataset.cat = cat;
+                btn.addEventListener('click', () => applyFilter(cat));
+                return btn;
+            };
+
+            filterBar.appendChild(makeBtn('All', ''));
+            allCats.forEach(cat => {
+                const label = cat.split('-').map(w => w[0].toUpperCase() + w.slice(1)).join(' ');
+                filterBar.appendChild(makeBtn(label, cat));
+            });
+            list.before(filterBar);
+
+            // Make sections collapsible
+            const sectionEls = sections.map(({ sec, heading, cats }) => {
+                sec.classList.add('tool-section');
+                sec.dataset.cats = cats.join(' ');
+                sec.dataset.open = 'false';
+
+                const headerDiv = document.createElement('div');
+                headerDiv.className = 'tool-header';
+                headerDiv.setAttribute('role', 'button');
+                headerDiv.setAttribute('tabindex', '0');
+
+                const toggleSpan = document.createElement('span');
+                toggleSpan.className = 'tool-toggle';
+                toggleSpan.setAttribute('aria-hidden', 'true');
+                toggleSpan.textContent = '▶';
+
+                // Wrap h2 in headerDiv; move all remaining children into bodyDiv
+                sec.insertBefore(headerDiv, heading);
+                heading.prepend(toggleSpan);
+                headerDiv.appendChild(heading);
+
+                const bodyDiv = document.createElement('div');
+                bodyDiv.className = 'tool-body';
+                bodyDiv.style.display = 'none';
+                while (sec.children.length > 1) {
+                    bodyDiv.appendChild(sec.children[1]);
                 }
-                }
+                sec.appendChild(bodyDiv);
+
+                const open = (scroll = false) => {
+                    bodyDiv.style.display = '';
+                    sec.dataset.open = 'true';
+                    if (scroll) setTimeout(() => heading.scrollIntoView({ behavior: 'smooth', block: 'start' }), 50);
+                };
+                const close = () => {
+                    bodyDiv.style.display = 'none';
+                    sec.dataset.open = 'false';
+                };
+                const handleToggle = () => sec.dataset.open === 'true' ? close() : open();
+
+                headerDiv.addEventListener('click', (e) => {
+                    if (e.target.closest('a')) return;
+                    handleToggle();
+                });
+                headerDiv.addEventListener('keydown', e => {
+                    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleToggle(); }
+                });
+
+                return { sec, heading, open, close };
+            });
+
+            // Open based on URL hash (Quarto puts the id on the <section>, not the <h2>)
+            const getHash = () => window.location.hash.split('#:~:')[0].slice(1);
+            const openByHash = (hash) => {
+                if (!hash) return;
+                const match = sectionEls.find(s => s.sec.id === hash);
+                if (match) match.open(true);
+            };
+            openByHash(getHash());
+            window.addEventListener('hashchange', () => openByHash(getHash()));
+
+            // Open based on Quarto search query or Google text fragment
+            const query = (__searchQuery || __textFragment || '').toLowerCase();
+            if (query) {
+                sectionEls.forEach(({ sec, open }) => {
+                    if (sec.textContent.toLowerCase().includes(query)) open();
+                });
             }
         });
         </script>
 ---
 
-The Vrije Universiteit Amsterdam hosts a wide range of research data management (RDM) tools designed for researchers to support researchers throughout their enitre project lifecycle. 
+The Vrije Universiteit Amsterdam hosts a wide range of research data management (RDM) tools designed to support researchers throughout their entire project lifecycle.
 
-Whether you are starting your data management plan, collecting data or looking for long-term storage solutions, RDM tools help you optimise your research process and make data handling efficient. 
+Whether you are starting your data management plan, collecting data, or looking for long-term storage solutions, RDM tools help you optimise your research process and make data handling efficient.
 
-## RDM tools
+::: {#tools-list}
 
-<details>
+## ADA {#ada .computing}
 
-<summary>Code Development Tools</summary>
+[ADA](/tools/ada/index.qmd) is VU's on-campus computing cluster for multi-node computations. ADA is beneficial when your research requires more computational power than a standard laptop or workstation. It offers access to multi-core CPUs, large-memory nodes, and batch GPU capacity for efficient large-scale data processing and analysis. Account needs to be requested via the VU Service Portal.
 
-VU Amsterdam has a GitLab instance in which you can collaboratorively work on code:
+## Amberscript {#amberscript .transcription}
 
-- [GitLab](https://gitlab.vu.nl) is a code repository for **research use**; features include version control and the possibility to collaborate. Maintained by the University Library. There is also a [gitlab server for general use](https://git.vu.nl).
+[Amberscript](../topics/transcription.qmd) offers both automated transcription and human-edited transcription. Human-edited transcriptions can be done verbatim or literal. This is a paid service available to VU researchers.
 
-</details>
+## ATLAS.ti {#atlasti .data-analysis}
 
-<details>
+[ATLAS.ti](https://atlasti.com/) is qualitative data analysis software that supports coding, text interpretation, and multimedia analysis. Instructions for using the VU ATLAS.ti licence are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&table=kb_knowledge&sys_id=e8a8a1f4874bc15010be65b40cbb351c). ATLAS.ti also provides [video tutorials](https://atlasti.com/video-tutorials) to help users get started.
 
-<summary>Computing Tools</summary>
+## DataverseNL {#dataversenl .data-archiving .data-publishing}
 
-There are several tools available to support researchers in performing computational analysis and processing data efficiently:
+[DataverseNL](/tools/dataversenl/index.qmd) is an open access data repository hosted by DANS for archiving and publishing research datasets. DataverseNL is not suitable for data files containing personal or confidential data. For archiving and publishing sensitive data, researchers should use [Yoda](#yoda).
 
-- [ADA](/tools/ada/index.qmd) is VU's on-campus computing cluster for multi-node computations. ADA is beneficial when your research requires more computational power than a standard laptop or workstation. It offers access to multi-core CPUs, large-memory nodes, and batch GPU capacity for effiecient large-scale data processing and analysis. Account needs to be requested via the VU Service Portal.
+## DMPonline {#dmponline .data-management-plan}
 
-- [Nebula](/tools/nebula/index.qmd) is developed to support researchers who want to use AI models in their work. It provides researchers across all departments with safe and seamless access to open-source large langugae models (LLMs). Nebula is fully hosted on VU premises ensuring that no data leaves the campus.
+[DMPonline](/tools/dmponline/index.qmd) is an online platform that enables researchers to create, manage, and share Data Management Plans. The platform provides structured templates to help researchers address key aspects of the research lifecycle, including legal and ethical requirements, storage, preservation, documentation, and responsibilities. Log in using VU credentials with Single Sign-on (SSO).
 
-- [Research Cloud](/tools/researchcloud/index.qmd) is a SURF-hosted portal that allows you to easily build or reuse a virtual research environment. It enables you to run one or more servers with applications that are accessible over the internet. Requires SRAM collaboration credentials and computing credits.
+## GitLab {#gitlab .code-development}
 
-- [SciCloud](/tools/scicloud/index.qmd) is offered by IT for Research ([ITvO](/topics/itvo.qmd)) and is based on the open-source middleware OpenNebula (ONE). It allows researchers to purchase server capacity to support their research applications. Good for web applications and 24/7 services.
+[GitLab](https://gitlab.vu.nl) is VU's code repository for research use. Features include version control and the possibility to collaborate on code. Maintained by the University Library. There is also a [GitLab server for general use](https://git.vu.nl).
 
-- [Snellius](/tools/snellius/index.qmd) is a National Supercomputer hosted by SURF, designed for large-scale experiments, such as simulations and modelling, that require significant computing power. Access can be requested through the VU contract with SURF or through an NWO compute grant.
+## iThenticate {#ithenticate .plagiarism-detection}
 
-- [VU Compute hub](/tools/vucomputehub/index.qmd) is a JupyterHub service hosted by IT that is primarily intended for educational use, but is also available to VU researchers who need a low-threshold environment for running analyses.
+[iThenticate](/tools/ithenticate/index.qmd) is plagiarism detection software offered by Turnitin that compares a researcher's work with published academic sources and bibliographic databases such as Crossref. At VU Amsterdam, plagiarism checks are used primarily in an educational and preventative way, with the aim of raising awareness of scientific integrity.
 
-</details>
+## MATLAB {#matlab .data-analysis}
 
-<details>
+[MATLAB](https://www.mathworks.com/academia/tah-portal/vrije-universiteit-amsterdam-30688271.html) is a programming language for numerical analysis, data visualisation, and algorithm development. Instructions for using the VU MATLAB licence are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0011916&table=kb_knowledge&searchTerm=matlab).
 
-<summary>Data Analysis Tools</summary>
+## Nebula {#nebula .computing}
 
-VU Amsterdam provides licences for several data analysis tools. The different software options provided by IT are described in the 🔒 [the VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0012864&table=kb_knowledge&searchTerm=spss).
+[Nebula](/tools/nebula/index.qmd) is developed to support researchers who want to use AI models in their work. It provides researchers across all departments with safe and seamless access to open-source large language models (LLMs). Nebula is fully hosted on VU premises, ensuring that no data leaves the campus.
 
-You can find more information on working with data in [the VU LibGuide 'Working with data'](https://libguides.vu.nl/working-with-data/introduction).
+## OSF {#osf .data-publishing .preregistration}
 
-If you have any questions about the tools listed below, you can contact the [IT Servicedesk](mailto:servicedesk.it@vu.nl). 
+[OSF](/tools/osf/index.qmd) is a cloud-based, open-source tool that supports researchers throughout the **active research stage**. It facilitates collaboration and connects services, materials, and other research objects for private use or public sharing. OSF also supports preregistration of research.
 
-- [ATLAS.ti](https://atlasti.com/) is a qualitative data analysis software that supports coding, text interpretation and multimedia analysis. You can find instructions for using the ATLAS.ti licence on the 🔒 [the VU Service Portal](https://services.vu.nl/esc?id=kb_article&table=kb_knowledge&sys_id=e8a8a1f4874bc15010be65b40cbb351c&recordUrl=%2Fkb_view.do%3Fsys_kb_id%3De8a8a1f4874bc15010be65b40cbb351c). ATLAS.ti provides [video tutorials](https://atlasti.com/video-tutorials) to help users get started. 
+## Pure {#pure .research-output-registration}
 
-- [SPSS](https://www.surfspot.nl/vu) is a quantitative statistical analysis software package used for data management, statistical analysis, and data visualisation. You can find instructions for using the SPSS licence on the 🔒 [the VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0022399&table=kb_knowledge&searchTerm=spss). There are [free tutorials](https://resultnetsearch.com/?dn=how2stats.net&sksubid=44786252&_slsen=0) available to help users get started. You can find more in-depth, paid tutorials by [Laerd Statistics](https://statistics.laerd.com/).
+[Pure](/tools/pure/index.qmd) is the Current Research Information System (CRIS) used at VU, serving as the central platform for registering and managing all research activities and outputs, including publications, datasets, research software/code, and projects. All researchers at VU Amsterdam have access to the back end and a public profile page.
 
-- [MATLAB](https://www.mathworks.com/academia/tah-portal/vrije-universiteit-amsterdam-30688271.html) is a programming language for numerical analysis, data visualisation, and algorithm development. You can find instructions for using the MATLAB licence on the 🔒 [the VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0011916&table=kb_knowledge&searchTerm=matlab).
+## Qualtrics {#qualtrics .online-survey}
 
-- [Stata](https://www.scienceplus.com/nl/statistiek/stata/?gad_source=1&gad_campaignid=251688141&gbraid=0AAAAAD_cwtmYS8azW8JFKlpADJ1WIR2yy&gclid=CjwKCAjwhqfPBhBWEiwAZo196pDjD5tymxrHz163VRmksMh8P6zM_YzEYpkzFDHlnssDHcKBoeMKEBoCRh4QAvD_BwE) is a statistical package used for quantitative data analysis. Stata is what IT calls 'a specific software package', meaning that it's only available for specific user groups. If you're unsure whether Stata is available for you, we recommend asking someone in your department (e.g. supervisor or head of research group). More information and tutorials can be found in [the VU LibGuide 'Working with data'](https://libguides.vu.nl/working-with-data/software/stata-sources).
+[Qualtrics](/tools/qualtrics/index.qmd) is a cloud-based survey platform that enables users to create and manage online surveys. It supports a variety of complex survey design requirements. VU's Qualtrics licence is intended for scientific research purposes only. Log in using VU credentials with Single Sign-on (SSO).
 
-</details>
+## Research Cloud {#research-cloud .computing .virtual-research-environment}
 
-<details>
+[Research Cloud](/tools/researchcloud/index.qmd) is a SURF-hosted portal that allows you to easily build or reuse a virtual research environment. It enables you to run one or more servers with applications that are accessible over the internet. Requires SRAM collaboration credentials and computing credits.
 
-<summary>Data Archiving Tools</summary>
+## Research Drive {#research-drive .data-storage}
 
-There are several tools available to support researchers in archiving their data:
+[Research Drive](/tools/researchdrive/index.qmd) is a SURF-hosted online storage and collaboration platform for research data. It allows researchers to easily store and share files with others, both within and outside VU Amsterdam. Data must be downloaded via Nextcloud to a local device for analysis. Fine-grained folder access rights are possible. Account needs to be requested via the VU Service Portal.
 
-- [DataverseNL](/tools/dataversenl/index.qmd) is a data repository hosted by DANS for archiving and publishing research datasets. DataverseNL is not suitable for data files containing personal or confidential data. For archiving and publishing sensitive data, researchers should use Yoda. 
+## SciCloud {#scicloud .computing .virtual-research-environment}
 
-- [Yoda](/tools/yoda/index.qmd) is a data storage platform and repository hosted by SURF. It supports researchers throughout the entire research lifecycle, from the safe and easy storage and sharing of data during the research process, to the sharing of data within research collaborations and ultimately to research data archiving and publication. Account needs to be requested via the VU Service Portal.
+[SciCloud](/tools/scicloud/index.qmd) is offered by IT for Research (ITvO) and is based on the open-source middleware OpenNebula (ONE). It allows researchers to purchase server capacity to support their research applications. Good for web applications and 24/7 services.
 
+## SciStor {#scistor .data-storage .file-transfer}
 
-</details>
+[SciStor](/tools/scistor/index.qmd) is an IT-hosted data storage service designed for storing large volumes of research data on campus. It provides high-speed connections to lab equipment, laptops, and workstations, and can connect to high-performance computers. Storage space needs to be requested via the VU Service Portal.
 
+## SciSure {#scisure .lab-journal}
 
-<details>
+[SciSure](/tools/scisure/index.qmd) is an application that supports researchers in documenting experiments and results in a digital lab journal. It can be used to track results and share data recorded during experiments within an electronic lab notebook.
 
-<summary>Data Management Plan Tools</summary>
+## Snellius {#snellius .computing}
 
-- [DMPonline](/tools/dmponline/index.qmd) is an online platform that enables researchers to create, manage, and share Data Management Plans. The platform provides structured templates to help researchers address key aspects of the research lifecycle, including legal and ethical requirements, storage, preservation, documentation, and responsibilities. Log in using VU credentials with Single Sign-on (SSO).
+[Snellius](/tools/snellius/index.qmd) is a National Supercomputer hosted by SURF, designed for large-scale experiments such as simulations and modelling that require significant computing power. Access can be requested through the VU contract with SURF or through an NWO compute grant.
 
+## SPSS {#spss .data-analysis}
 
-</details>
+[SPSS](https://www.surfspot.nl/vu) is a statistical analysis software package used for data management, statistical analysis, and data visualisation. Instructions for using the VU SPSS licence are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0022399&table=kb_knowledge&searchTerm=spss). Free tutorials are available from [how2stats](https://how2stats.net/); more in-depth paid tutorials from [Laerd Statistics](https://statistics.laerd.com/).
 
+## Stata {#stata .data-analysis}
 
-<details>
+[Stata](https://www.scienceplus.com/nl/statistiek/stata/) is a statistical package used for quantitative data analysis. Stata is only available for specific user groups — if you are unsure whether Stata is available to you, ask your supervisor or head of research group. More information and tutorials can be found in the [VU LibGuide 'Working with data'](https://libguides.vu.nl/working-with-data/software/stata-sources).
 
-<summary>Data Publishing Tools</summary>
+## SURFfilesender {#surffilesender .file-transfer}
 
-There are several tools available to support researchers in publishing data:
+[SURFfilesender](https://filesender.surf.nl/?s=home) is a web-based application that allows authenticated users to securely send arbitrarily large files to other users. Users without an account can be sent a guest upload voucher by an authenticated user. Log in using VU credentials with Single Sign-on (SSO).
 
-- [DataverseNL](/tools/dataversenl/index.qmd) is an open access platform hosted by Data Archiving and Networked Services (DANS) for archiving and publishing research datasets. DataverseNL is not suitable for data files containing personl or confidential data. For archiving and publishing sensitive data, researchers should use Yoda. 
+## Transcript Online {#transcript-online .transcription}
 
-- [OSF](/tools/osf/index.qmd) is a cloud-based, open-source tool that supports researchers throughout the **active research stage**. It facilitates collaboration and connects services, materials, and other research objects for private use or public sharing.
+[Transcript Online](../topics/transcription.qmd) offers human-edited transcription. Experienced transcribers convert speech in audio or video files into both verbatim and literal transcriptions. This is a paid service available to VU researchers.
 
-- [Yoda](/tools/yoda/index.qmd) is a data storage platform and repository hosted by SURF. It supports researchers throughout the entire research lifecycle, from the safe and easy storage and sharing of data during the research process, to the sharing of data within research collaborations and ultimately to research data archiving and publication. Account needs to be requested via the VU Service Portal.
+## VU Compute Hub {#vu-compute-hub .computing}
 
-</details>
+[VU Compute Hub](/tools/vucomputehub/index.qmd) is a JupyterHub service hosted by IT primarily intended for educational use, but also available to VU researchers who need a low-threshold environment for running analyses.
 
+## Yoda {#yoda .data-archiving .data-publishing .data-storage}
 
-<details>
+[Yoda](/tools/yoda/index.qmd) is a data storage platform and repository hosted by SURF. It supports researchers throughout the entire research lifecycle, from safe storage and sharing during the research process, to sharing within research collaborations, and ultimately to data archiving and publication. Account needs to be requested via the VU Service Portal.
 
-<summary>Data Storage Tools</summary>
+## Zivver {#zivver .file-transfer}
 
-There are several tools available to support researchers in storing data in a way that suits their research project. The [Data Storage Finder](https://vu.nl/en/research/storagefinder) can help you decide which storage platforms fit your situation best.
+[Zivver](https://www.zivver.com/products/email-encryption-software) offers a secure way to send encrypted emails and file attachments up to 5TB. This is available to all VU employees. Instructions for using Zivver are on the 🔒 [VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0012157).
 
-- [Research Drive](/tools/researchdrive/index.qmd) is a SURF-hosted online storage and collaboration platform for research data. It allows researchers to easily store and share files with others, both within and outside VU Amsterdam. Research Drive is a cloud storage platform that requires downloading data using Nextcloud to a local device for analysis. Fine-grained distribution of folder access rights is possible. Account needs to be requested via the VU Service Portal. 
+:::
 
-- [SciStor](/tools/scistor/index.qmd) is an IT-hosted data storage service designed for storing large volumes of research data on campus. It provides high-speed connections to lab equipment, laptops, and workstations. Connecting to high-performance computers is possible. Storage space needs to be requested via the VU Service Portal.
 
-- [Yoda](/tools/yoda/index.qmd) is a data storage platform and repository hosted by SURF. It supports researchers throughout the entire research lifecycle, from the safe and easy storage and sharing of data during the research process, to the sharing of data within research collaborations and ultimately to research data archiving and publication. Account needs to be requested via the VU Service Portal.
-
-</details>
-
-<details>
-
-<summary>File Transfer Tools</summary>
-
-A storage platform that allows (external) sharing is the easiest way to share data with others working on your project. This is possible with [Yoda](/tools/yoda/index.qmd) and [Research Drive](/tools/researchdrive/index.qmd) (with VU-internal and external colleagues) and with [SciStor](/tools/scistor/index.qmd) (only with VU colleagues). However, sometimes you might need to send data to a third party as a one-off. Regular email is not suitable for sending sensitive data, but there are alternatives:
-
-- [SURFfilesender](https://filesender.surf.nl/?s=home) is a web-based application that allows authenticated users to securely and easily send arbitrarily large files to other users. Users without an account can be sent a guest upload voucher by an authenticated user. SURFfilesender is developed to the requirements of the higher education and research community. Log in using VU credentials with Single Sign-on (SSO).
-
-- [Zivver](https://www.zivver.com/products/email-encryption-software) offers a secure way to send (large) files. With Zivver, you can encrypt your emails and attachments up to 5TB. This is available to all VU employees. You can find information on how to use Zivver in 🔒 [the VU Service Portal](https://services.vu.nl/esc?id=kb_article&sysparm_article=KB0012157). Encrypted email and file transfer with attachments up to 5TB.
-
-</details>
-
-<details>
-
-<summary>Lab Journal Tools</summary>
-
-- [SciSure](/tools/scisure/index.qmd) is an application that supports researchers in documenting experiments and results in a digital lab journal. It can be used to track results and share data recorded during experiments within an electronic lab notebook.
-
-
-</details>
-
-<details>
-
-<summary>Online Survey Tools</summary>
-
-- [Qualtrics](/tools/qualtrics/index.qmd) is a cloud-based survey platform that enables users to create and manage online surveys. It supports a variety of (complex) survey design requirements. VU’s Qualtrics licence is intended for scientific research purposes only, including data collection and management. Log in using VU credentials with Single Sign-on (SSO).
-
-</details>
-
-<details>
-
-<summary>Plagiarism Detection Tools</summary>
-
-- [iThenticate](/tools/ithenticate/index.qmd) is plagiarism detection software offered by Turnitin that compares a researcher’s work with published academic sources and bibliographic databases such as Crossref. At VU Amsterdam, plagiarism checks are used primarily in an educational and preventative way, with the aim of raising awareness of scientific integrity rather than focusing on retrospective detection.
-</details>
-
-<details>
-
-<summary>Preregistration Tools</summary>
-
-- [OSF](/tools/osf/index.qmd) is a cloud-based, open-source tool that supports researchers throughout the **active research stage**. It facilitates collaboration and connects services, materials, and other research objects for private use or public sharing.
-
-</details>
-
-<details>
-
-<summary>Research Output Registration Tools</summary>
-
-- [Pure](/tools/pure/index.qmd) is the Current Research Information System (CRIS) used at VU, serving as the central platform for registering and managing all research activities and outputs, including publications, datasets, research software/code, and projects. All researchers at VU Amsterdam have access to the back end and a public profile page.
-
-</details>
-
-<details>
-
-<summary>Transcription Tools</summary>
-
-VU Amsterdam has agreements with two transcription services for converting speech in audio or video files to text:
-
-- [Transcript Online](../topics/transcription.qmd) offers human-edited transcription. Experienced transcribers convert speech into both verbatim and literal transcriptions. This is a paid service.
-
-- [Amberscript](../topics/transcription.qmd) offers both automated transcription and human-edited transcription. Human-edited transcriptions can be done verbatim or literal. This is a paid service.
-
-</details>
-
-<details>
-
-<summary>Virtual Research Environment Tools</summary>
-
-There are several tools available to support researchers in building and using virtual research environments efficiently:
-
-- [Research Cloud](/tools/researchcloud/index.qmd) is a SURF-hosted portal that allows you to easily build or reuse a virtual research environment. It enables you to run one or more servers with applications that are accessible over the internet.
-
-- [SciCloud](/tools/scicloud/index.qmd) is based on the open-source middleware OpenNebula (ONE) and allows researchers to purchase server capacity to support their research applications.
-
-</details>
 
 ## Choosing a Tool
 
-Which tool is most suitable for your research can vary, depending on what kind of functionality you're looking for, what sort of data you're dealing with, or whether you need to share data with external partners. Not sure which tools fits your project? The [RDM Support Desk](mailto:rdm.vu.nl) is available to provide you with the guidance throughout your entire project lifecycle.
+Which tool is most suitable for your research can vary, depending on what kind of functionality you're looking for, what sort of data you're dealing with, or whether you need to share data with external partners. Not sure which tool fits your project? The [RDM Support Desk](mailto:rdm@vu.nl) is available to provide guidance throughout your entire project lifecycle.
 
 ### Data Storage Finder
 
@@ -222,10 +289,10 @@ Specifically for data storage tools, the [Data Storage Finder](https://vu.nl/en/
 
 ### Overviews
 
-A subset of the tools listed above is highlighted in the video below ([DMPonline](/tools/dmponline/index.qmd), [DataverserNL](/tools/dataversenl/index.qmd), [Yoda](/tools/yoda/index.qmd), [OSF](/tools/osf/index.qmd), [Research Drive](/tools/researchdrive/index.qmd), [SciStor](/tools/scistor/index.qmd)). This is a nice resource if you'd like a quick, visual overview of these tools.
+A subset of the tools listed above is highlighted in the video below ([DMPonline](/tools/dmponline/index.qmd), [DataverseNL](/tools/dataversenl/index.qmd), [Yoda](/tools/yoda/index.qmd), [OSF](/tools/osf/index.qmd), [Research Drive](/tools/researchdrive/index.qmd), [SciStor](/tools/scistor/index.qmd)). This is a nice resource if you'd like a quick, visual overview of these tools.
 
 <!-- markdownlint-disable MD033 -->
-<div style="position: relative; width: 100%; height: 0; padding-bottom: 56.25%">	
+<div style="position: relative; width: 100%; height: 0; padding-bottom: 56.25%">
 <iframe src="https://vu.cloud.panopto.eu/Panopto/Pages/Embed.aspx?id=8357c8b8-3983-422d-a48e-b3a900b38cf1&autoplay=false&offerviewer=true&showtitle=true&showbrand=true&captions=false&interactivity=all" style="border: 1px solid #464646; position: absolute; top: 0; left: 0; width: 100%; height: 100%; box-sizing: border-box;" allowfullscreen allow="autoplay" aria-label="Panopto Embedded Video Player" aria-description="VU RDM - RDM tools V3 + subs"></iframe>
 </div>
 <!-- markdownlint-enable MD033 -->
@@ -237,4 +304,3 @@ The image below lists all services and tools provided by the Network Research Da
 ## Tool Not Listed?
 
 If you need a research tool that isn't provided by VU Amsterdam, you can contact the RDM Support Desk at [rdm@vu.nl](mailto:rdm@vu.nl) to discuss your requirements. We can suggest an alternative or forward your question to IT or the procurement team.
-

--- a/topics/rdm-tools.qmd
+++ b/topics/rdm-tools.qmd
@@ -174,7 +174,7 @@ Click on a category to filter the list.
 
 [SciCloud](/tools/scicloud/index.qmd) is offered by IT for Research (ITvO) and is based on the open-source middleware OpenNebula (ONE). It allows researchers to purchase server capacity to support their research applications. Good for web applications and 24/7 services.
 
-### SciStor {#scistor .data-storage .file-transfer}
+### SciStor {#scistor .data-storage}
 
 [SciStor](/tools/scistor/index.qmd) is an IT-hosted data storage service designed for storing large volumes of research data on campus. It provides high-speed connections to lab equipment, laptops, and workstations, and can connect to high-performance computers. Storage space needs to be requested via the VU Service Portal.
 


### PR DESCRIPTION
I'm experimenting with Claude AI and put in the requirements in #837. It came up with this solution which functions really well. The javascript is pretty minimal and even if you delete it all the information remains accessible.

The first version I had was with the tool descriptions collapsible, but that just means a user has to click twice.

Each tool name should have a heading 3  a `#<name>` and can have multiple `.<category-name>` , for example: 
`### Yoda {#yoda .data-archiving .data-publishing .data-storage}`. If you use a new category it will automatically show up in the list.

For readability I would suggest removing the image and video.

@Jolien-S, what do you think? 