### PR TITLE
Update checkout action version to v6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Fixes a deprecation error when the site is published to github. There is also a v7, but it's really new. 

I will check the logs after this PR is merged to see if everything still works.

Closes #844
