### PR TITLE
bump create-pull-request version

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -27,7 +27,7 @@ jobs:
             - name: Collect contributor data
               run: Rscript -e 'allcontributors::add_contributors(repo = ".", files = c("about.qmd", "README.md"), num_sections = 1)'
             - name: Create Pull Request
-              uses: peter-evans/create-pull-request@v5
+              uses: peter-evans/create-pull-request@v8
               with:
                 commit-message: "Update contributors"
                 branch: update-contributors


### PR DESCRIPTION
I missed that this action also has a new version yesterday. The "Collect contributors" action fails when I tried to run it, will retry after this PR is merged.