### PR TITLE
Mention "active data" on `data-storage.qmd`

### DIFF
--- a/topics/data-storage.qmd
+++ b/topics/data-storage.qmd
@@ -3,7 +3,7 @@ title: Data Storage
 categories: [Research Data]
 ---
 
-VU Amsterdam offers several options to store your digital research data. The choice for a specific option depends on factors such as:
+VU Amsterdam offers several options for storage of active research data, that is: research data you work with during your project. The choice for a specific option depends on factors such as:
 
 * Does a project involve multiple organisations or departments?
 * The sensitivity of the data: does it involve personal data or copyrighted / commercial data?


### PR DESCRIPTION
We use the term Active Storage in the Handbook, especially in the context of Yoda  (as opposed to Archive Storage), but it's not explained anywhere. 

This PR modifies the first sentence in `data-storage.qmd` to mention that it's about Active data. 

Closes #880