### PR TITLE
ResearchCloud update

### DIFF
--- a/tools/researchcloud/index.qmd
+++ b/tools/researchcloud/index.qmd
@@ -21,3 +21,12 @@ SURF Research Cloud enables you to run 1 or more servers with applications that 
 - Running a desktop environment with analysis tools, use your favourite desktop tools on an environment with more performance. Unlike for SciCloud, GPU resources are available. You can easily connect an environment to your data on Research Drive or Yoda.
 
 - Hosting a highly secure research environment where sensitive data cannot leave the VRE: [SURF SANE](https://www.surf.nl/en/themes/research-infrastructure/sane-secure-environment-for-analysing-sensitive-data).
+
+Some examples of applications currently available in the Research Cloud catalog:
+- R workbench 
+- RStudio
+- SAS
+- ASReview 
+- Galaxy
+- Open WebUI with Ollama
+- OpenRefine 

--- a/tools/researchcloud/quick_start.qmd
+++ b/tools/researchcloud/quick_start.qmd
@@ -4,4 +4,6 @@ title: Quick Start
 
 Documentation for Research Cloud can be found on the [SURF User Knowledge Base](https://servicedesk.surf.nl/wiki/display/WIKI/SURF+Research+Cloud).
 
+Utrecht University has [online documentation](https://utrechtuniversity.github.io/vre-docs/) about the [Workspaces](https://utrechtuniversity.github.io/vre-docs/docs/workspace-catalogue.html) they offer to their researchers. Most of the applications mentioned there can be used by others as well. 
+
 [IT for Research](mailto:itvo.it@vu.nl) can assist you in setting up a new Research Cloud environment.


### PR DESCRIPTION
- Added a link to the excellent UU documentation site.
- Added some examples of applications that run on Research Cloud

Some context: 
we recently had 2 research groups wanting to use [ASReview](https://asreview.nl/), which is really easy to setup on RC. We don't support ASReview, so I don't want to add it to the tools page, but this way it can at least be found in the handbook.

Closes #904   